### PR TITLE
Add launch arguments to apex_rostest

### DIFF
--- a/apex_rostest/apex_rostest/apex_rostest_main.py
+++ b/apex_rostest/apex_rostest/apex_rostest_main.py
@@ -1,5 +1,22 @@
 # Copyright 2019 Apex.AI, Inc.
 # All rights reserved.
+#
+# This file contains modified code from the following open source projects
+# published under the licenses listed below:
+#
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import argparse
 import logging
@@ -20,6 +37,33 @@ def _load_python_file_as_module(python_file_path):
     return loader.load_module()
 
 
+def print_launch_arguments(launch_arguments):
+    # TODO (pete baughman) See if OSRF will take a PR to refactor ros2launch.api
+    # so I can call this function without copy/pasting it.  This snippit is the reason
+    # for the extra copyright notice at the top of this file
+    print("Arguments (pass arguments as '<name>:=<value>'):")
+    any_conditional_arguments = False
+    for argument_action in launch_arguments:
+        msg = "\n    '"
+        msg += argument_action.name
+        msg += "':"
+        if argument_action._conditionally_included:
+            any_conditional_arguments = True
+            msg += '*'
+        msg += '\n        '
+        msg += argument_action.description
+        if argument_action.default_value is not None:
+            default_str = ' + '.join([token.describe() for token in argument_action.default_value])
+            msg += '\n        (default: {})'.format(default_str)
+        print(msg)
+
+    if len(launch_arguments) > 0:
+        if any_conditional_arguments:
+            print('\n* argument(s) which are only used if specific conditions occur')
+    else:
+        print('\n  No arguments.')
+
+
 def apex_rostest_main():
 
     logging.basicConfig()
@@ -34,6 +78,17 @@ def apex_rostest_main():
                         action="store_true",
                         default=False,
                         help="Run with verbose output")
+
+    parser.add_argument('-s', '--show-args', '--show-arguments',
+                        action='store_true',
+                        default=False,
+                        help='Show arguments that may be given to the test file.')
+
+    parser.add_argument(
+        'launch_arguments',
+        nargs='*',
+        help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)"
+    )
 
     parser.add_argument(
         "--junit-xml",
@@ -70,7 +125,8 @@ def apex_rostest_main():
 
     runner = ApexRunner(
         gen_launch_description_fn=dut_test_description_func,
-        test_module=test_module
+        test_module=test_module,
+        launch_file_arguments=args.launch_arguments
     )
 
     _logger_.debug("Validating test configuration")
@@ -78,6 +134,10 @@ def apex_rostest_main():
         runner.validate()
     except Exception as e:
         parser.error(e)
+
+    if args.show_args:
+        print_launch_arguments(runner.get_launch_args())
+        sys.exit(0)
 
     _logger_.debug("Running integration test")
     try:

--- a/apex_rostest/apex_rostest/asserts/assert_output.py
+++ b/apex_rostest/apex_rostest/asserts/assert_output.py
@@ -23,7 +23,7 @@ def _assertInStdoutByProcessAction(
         if msg in output.text.decode('ascii'):
             return
     else:
-        assert False, "Did not find '{}' in output for {} {}".format(
+        assert False, "Did not find '{}' in output for {}".format(
             msg,
             _proc_to_name_and_args(process_action)
         )

--- a/apex_rostest/apex_rostest/util/__init__.py
+++ b/apex_rostest/apex_rostest/util/__init__.py
@@ -3,7 +3,14 @@
 
 
 from launch_ros.actions import Node as __rl_node
+from .message_pump import MessagePump
 
 
 def EmptyNode():
     return __rl_node(package='apex_rostest', node_executable='empty_node')
+
+
+__all__ = [
+    'EmptyNode',
+    'MessagePump',
+]

--- a/apex_rostest/apex_rostest/util/message_pump.py
+++ b/apex_rostest/apex_rostest/util/message_pump.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Apex.AI, Inc.
+# All rights reserved.
+
+import threading
+
+import rclpy
+
+
+class MessagePump:
+    """Calls rclpy.spin on a thread so tests don't need to."""
+
+    def __init__(self, node):
+        self._node = node
+        self._thread = threading.Thread(
+            target=self._run,
+            name="msg_pump_thread",
+        )
+        self._run = True
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._run = False
+        self._thread.join(timeout=5.0)
+        if self._thread.is_alive():
+            raise Exception("Timed out waiting for message pump to stop")
+
+    def _run(self):
+        while self._run:
+            rclpy.spin_once(self._node, timeout_sec=1.0)

--- a/apex_rostest/examples/test_with_args.test.py
+++ b/apex_rostest/examples/test_with_args.test.py
@@ -1,0 +1,66 @@
+# Copyright 2018 Apex.AI, Inc.
+# All rights reserved.
+
+import unittest
+
+from launch import LaunchDescription
+import launch.actions
+import launch.substitutions
+import launch_ros.actions
+
+import apex_rostest
+import apex_rostest.asserts
+import apex_rostest.util
+
+
+dut_node = launch_ros.actions.Node(
+    package='apex_rostest',
+    node_executable='terminating_node',
+    arguments=[launch.substitutions.LaunchConfiguration('dut_node_arg')],
+)
+
+
+def generate_test_description(ready_fn):
+
+    return LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'dut_node_arg',
+            default_value=['default'],
+            description='Passed to the terminating node',
+        ),
+        dut_node,
+        apex_rostest.util.EmptyNode(),
+        launch.actions.OpaqueFunction(function=lambda context: ready_fn())
+    ])
+
+
+class TestTerminatingNodeStops(unittest.TestCase):
+
+    def test_node_terminates(self):
+        self.proc_info.assertWaitForShutdown(process=dut_node, timeout=10)
+
+
+@apex_rostest.post_shutdown_test()
+class TestNodeOutput(unittest.TestCase):
+
+    def test_ran_with_arg(self):
+        self.assertNotIn(
+            'default',
+            dut_node.process_details['cmd'],
+            "Try running: apex_rostest test_with_args.test.py dut_node_arg:=arg"
+        )
+
+    def test_arg_printed_in_output(self):
+        apex_rostest.asserts.assertInStdout(
+            self.proc_output,
+            self.test_args['dut_node_arg'],
+            dut_node
+        )
+
+    def test_default_not_printed(self):
+        with self.assertRaises(AssertionError):
+            apex_rostest.asserts.assertInStdout(
+                self.proc_output,
+                "default",
+                dut_node
+            )

--- a/apex_rostest/package.xml
+++ b/apex_rostest/package.xml
@@ -9,6 +9,7 @@
 
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/apex_rostest/setup.py
+++ b/apex_rostest/setup.py
@@ -14,8 +14,9 @@ setup(
     author_email='pete.baughman@apex.ai',
 
     data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/apex_rostest']),
         ('lib/' + package_name, glob.glob('example_nodes/**')),
-        ('share/' + package_name + '/examples', glob.glob('examples/**')),
+        ('share/' + package_name + '/examples', glob.glob('examples/[!_]**')),
         ('bin', ['scripts/apex_rostest']),
     ],
     packages=[

--- a/apex_rostest/test/test_io_handler_and_assertions.py
+++ b/apex_rostest/test/test_io_handler_and_assertions.py
@@ -140,5 +140,9 @@ class TestIoHandlerAndAssertions(unittest.TestCase):
         assertInStdout(self.proc_output, txt, "terminating_node", NO_CMD_ARGS)
 
     def test_asserts_on_missing_text(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(AssertionError, self.NOT_FOUND_TEXT):
             assertInStdout(self.proc_output, self.NOT_FOUND_TEXT, "terminating", NO_CMD_ARGS)
+
+    def test_asserts_on_missing_text_by_node(self):
+        with self.assertRaisesRegex(AssertionError, self.NOT_FOUND_TEXT):
+            assertInStdout(self.proc_output, self.NOT_FOUND_TEXT, self.node_2)


### PR DESCRIPTION
 - Arguments work like regular launch arguments: apex_rostest name_of_test.py arg:=foo
 - Added a mesasge pump class that will spin some rclpy nodes on a background thread automatically

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/apex_rostest/1)
<!-- Reviewable:end -->
