### PR TITLE
More output when node dies

### DIFF
--- a/apex_launchtest/example_processes/terminating_proc
+++ b/apex_launchtest/example_processes/terminating_proc
@@ -29,6 +29,9 @@ if __name__ == "__main__":
     if sys.argv[1:]:
         print("Called with arguments {}".format(sys.argv[1:]))
 
+    if '--exception' in sys.argv[1:]:
+        raise Exception("Process had a pretend error")
+
     try:
         print("Emulating Work")
         time.sleep(1.0)


### PR DESCRIPTION
It can be hard to understand why processes under test die early before the tests are finished.  This update will print the stderr and stdout of these processes to help debug what happened

#### Depends on
 - ~~https://github.com/ApexAI/apex_rostest/pull/6~~
 - ~~https://github.com/ApexAI/apex_rostest/pull/8~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/apex_rostest/12)
<!-- Reviewable:end -->
