### PR TITLE
Fix coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.egg-info
 *.pyc
 *.pytest_cache
+*.coverage
 htmlcov/
 
 build/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ build_all:
   stage: build
   image: osrf/ros2:nightly
   script:
-    - colcon build
+    - colcon build --symlink-install
   artifacts:
     paths:
       - build
@@ -71,8 +71,8 @@ coverage:
   script:
     - pip3 install coverage
     - find . -iname ".coverage" -exec coverage combine -a {} \;
-    - coverage report --include=*/site-packages/apex*
-    - coverage html --include=*/site-packages/apex*
+    - coverage report --include=apex_launchtest*
+    - coverage html --include=apex_launchtest*
   coverage: '/TOTAL\s+\d+\s+\d+\s+(\d+\%)/'
   artifacts:
     paths:


### PR DESCRIPTION
 - Use symlink-install, otherwise coverage we get through subprocess calls ends up
   in a different place than coverage we get through calling functions directly from
   tests