### PR TITLE
Have IO and Exit Code asserts use the same lookup

### DIFF
--- a/apex_launchtest/apex_launchtest/asserts/__init__.py
+++ b/apex_launchtest/apex_launchtest/asserts/__init__.py
@@ -19,9 +19,10 @@ from .assert_exit_codes import EXIT_SIGQUIT
 from .assert_exit_codes import EXIT_SIGKILL
 from .assert_exit_codes import EXIT_SIGSEGV
 from .assert_output import assertInStdout
-from .assert_output import NO_CMD_ARGS
 from .assert_sequential_output import assertSequentialStdout
 from .assert_sequential_output import SequentialTextChecker
+
+from ..util.proc_lookup import NO_CMD_ARGS
 
 __all__ = [
     'assertExitCodes',

--- a/apex_launchtest/apex_launchtest/asserts/assert_exit_codes.py
+++ b/apex_launchtest/apex_launchtest/asserts/assert_exit_codes.py
@@ -23,7 +23,7 @@ EXIT_SIGSEGV = 139
 
 def assertExitCodes(proc_info,
                     allowable_exit_codes=[EXIT_OK],
-                    proc=None,  # By default, checks all processes
+                    process=None,  # By default, checks all processes
                     cmd_args=None,
                     *,
                     strict_proc_matching=True):
@@ -39,7 +39,7 @@ def assertExitCodes(proc_info,
 
     to_check = resolveProcesses(
         info_obj=proc_info,
-        proc=proc,
+        process=process,
         cmd_args=cmd_args,
         strict_proc_matching=strict_proc_matching
     )

--- a/apex_launchtest/apex_launchtest/asserts/assert_exit_codes.py
+++ b/apex_launchtest/apex_launchtest/asserts/assert_exit_codes.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ..util import resolveProcesses
+
 EXIT_OK = 0
 EXIT_SIGINT = 130
 EXIT_SIGQUIT = 131
@@ -19,7 +21,12 @@ EXIT_SIGKILL = 137
 EXIT_SIGSEGV = 139
 
 
-def assertExitCodes(proc_info, allowable_exit_codes=[EXIT_OK]):
+def assertExitCodes(proc_info,
+                    allowable_exit_codes=[EXIT_OK],
+                    proc=None,  # By default, checks all processes
+                    cmd_args=None,
+                    *,
+                    strict_proc_matching=True):
     """
     Check the exit codes of the processes under test.
 
@@ -30,7 +37,14 @@ def assertExitCodes(proc_info, allowable_exit_codes=[EXIT_OK]):
     for code in allowable_exit_codes:
         assert isinstance(code, int), "Provided exit code {} is not an int".format(code)
 
-    for info in proc_info:
+    to_check = resolveProcesses(
+        info_obj=proc_info,
+        proc=proc,
+        cmd_args=cmd_args,
+        strict_proc_matching=strict_proc_matching
+    )
+
+    for info in [proc_info[item] for item in to_check]:
         assert info.returncode in allowable_exit_codes, "Proc {} exited with code {}".format(
             info.process_name,
             info.returncode

--- a/apex_launchtest/apex_launchtest/asserts/assert_output.py
+++ b/apex_launchtest/apex_launchtest/asserts/assert_output.py
@@ -12,89 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import launch.actions
-
-NO_CMD_ARGS = object()
-
-
-def _proc_to_name_and_args(proc):
-    # proc is a launch.actions.ExecuteProcess
-    return "{} {}".format(
-        proc.process_details['name'],
-        " ".join(proc.process_details['cmd'][1:])
-    )
-
-
-def _assertInStdoutByProcessAction(
-        proc_output,
-        msg,
-        process_action):
-
-    for output in proc_output[process_action]:
-        if msg in output.text.decode('ascii'):
-            return
-    else:
-        assert False, "Did not find '{}' in output for {}".format(
-            msg,
-            _proc_to_name_and_args(process_action)
-        )
-
-
-def _assertInStdoutByStringProcessName(
-        proc_output,
-        msg,
-        proc_name,
-        cmd_args,
-        strict_proc_matching):
-
-    # Ensure that the combination proc_name and cmd_args are not ambiguous.  If they are,
-    # we need to cause an error to bubble up in order to alert the test writer that we may not
-    # be checking what they intend to check
-
-    def name_match_fn(proc):
-        return proc_name in proc.process_details['name']
-
-    def cmd_match_fn(proc):
-        if cmd_args is None:
-            return True
-        elif cmd_args is NO_CMD_ARGS:
-            return len(proc.process_details['cmd']) == 1
-        else:
-            return cmd_args in proc.process_details['cmd'][1:]
-
-    unique_procs = proc_output.processes()
-    matching_procs = [proc for proc in unique_procs if name_match_fn(proc) and cmd_match_fn(proc)]
-
-    if len(matching_procs) == 0:
-        proc_names = ', '.join(sorted([_proc_to_name_and_args(proc) for proc in unique_procs]))
-
-        raise Exception(
-            "Did not find any processes matching name '{}' and args '{}'. Procs: {}".format(
-                proc_name,
-                cmd_args,
-                proc_names
-            )
-        )
-    elif strict_proc_matching and len(matching_procs) > 1:
-        proc_names = ', '.join(sorted([_proc_to_name_and_args(proc) for proc in matching_procs]))
-        raise Exception(
-            "Found multiple processes matching name '{}' and cmd_args '{}'. Procs: {}".format(
-                proc_name,
-                cmd_args,
-                proc_names
-            )
-        )
-
-    for proc in matching_procs:  # Nominally just one matching proc
-        for output in proc_output[proc]:
-            if msg in output.text.decode('ascii'):
-                return
-    else:
-        assert False, "Did not find '{}' in output for process {} {}".format(
-            msg,
-            proc_name,
-            cmd_args
-        )
+from ..util import resolveProcesses
 
 
 def assertInStdout(proc_output,
@@ -126,22 +44,20 @@ def assertInStdout(proc_output,
     an error.
     :type strict_proc_matching: bool
     """
-    # Depending on the type of 'proc' we're going to dispatch this a little differently
-    if isinstance(proc, launch.actions.ExecuteProcess):
-        _assertInStdoutByProcessAction(
-            proc_output,
-            msg,
-            proc
-        )
-    elif isinstance(proc, str):
-        _assertInStdoutByStringProcessName(
-            proc_output,
-            msg,
-            proc,
-            cmd_args,
-            strict_proc_matching
-        )
+    resolved_procs = resolveProcesses(
+        info_obj=proc_output,
+        proc=proc,
+        cmd_args=cmd_args,
+        strict_proc_matching=strict_proc_matching
+    )
+
+    for proc in resolved_procs:  # Nominally just one matching proc
+        for output in proc_output[proc]:
+            if msg in output.text.decode('ascii'):
+                return
     else:
-        raise TypeError(
-            "proc argument must be 'ExecuteProcess' or 'str' not {}".format(type(proc))
+        names = ', '.join(sorted([p.process_details['name'] for p in resolved_procs]))
+        assert False, "Did not find '{}' in output for any of the matching process {}".format(
+            msg,
+            names
         )

--- a/apex_launchtest/apex_launchtest/asserts/assert_output.py
+++ b/apex_launchtest/apex_launchtest/asserts/assert_output.py
@@ -17,7 +17,7 @@ from ..util import resolveProcesses
 
 def assertInStdout(proc_output,
                    msg,
-                   proc,
+                   process,
                    cmd_args=None,
                    *,
                    strict_proc_matching=True):
@@ -31,10 +31,10 @@ def assertInStdout(proc_output,
     :param msg: The message to search for
     :type msg: string
 
-    :param proc: The process whose output will be searched
-    :type proc: A string (search by process name) or a launch.actions.ExecuteProcess object
+    :param process: The process whose output will be searched
+    :type process: A string (search by process name) or a launch.actions.ExecuteProcess object
 
-    :param cmd_args: Optional.  If 'proc' is a string, cmd_args will be used to disambiguate
+    :param cmd_args: Optional.  If 'process' is a string, cmd_args will be used to disambiguate
     processes with the same name.  Pass apex_launchtest.asserts.NO_CMD_ARGS to match a proc without
     command arguments
     :type cmd_args: string
@@ -46,14 +46,14 @@ def assertInStdout(proc_output,
     """
     resolved_procs = resolveProcesses(
         info_obj=proc_output,
-        proc=proc,
+        process=process,
         cmd_args=cmd_args,
         strict_proc_matching=strict_proc_matching
     )
 
     for proc in resolved_procs:  # Nominally just one matching proc
         for output in proc_output[proc]:
-            if msg in output.text.decode('ascii'):
+            if msg in output.text.decode():
                 return
     else:
         names = ', '.join(sorted([p.process_details['name'] for p in resolved_procs]))

--- a/apex_launchtest/apex_launchtest/asserts/assert_sequential_output.py
+++ b/apex_launchtest/apex_launchtest/asserts/assert_sequential_output.py
@@ -14,6 +14,8 @@
 
 from contextlib import contextmanager
 
+from ..util import resolveProcesses
+
 
 class SequentialTextChecker:
     """Helper class for asserting that text is found in a certain order."""
@@ -53,21 +55,30 @@ class SequentialTextChecker:
 
 @contextmanager
 def assertSequentialStdout(proc_output,
-                           proc):
+                           proc,
+                           cmd_args=None):
     """
     Create a context manager used to check stdout occured in a specific order.
 
     :param proc_output:  The captured output from a test run
-    :param proc: The process that generated the output we intend to check
+
+    :param proc: The process whose output will be searched
+    :type proc: A string (search by process name) or a launch.actions.ExecuteProcess object
+
+    :param cmd_args: Optional.  If 'proc' is a string, cmd_args will be used to disambiguate
+    processes with the same name.  Pass apex_launchtest.asserts.NO_CMD_ARGS to match a proc without
+    command arguments
+    :type cmd_args: string
     """
-    # TODO (pete baughman): Unify this proc lookup [FTR2549]
-    if isinstance(proc, str):
-        for process_action in proc_output.processes():
-            if proc in process_action.process_details['name']:
-                proc = process_action
-                break
-        else:
-            raise Exception("Did not find process matching name '{}'".format(proc))
+    proc = resolveProcesses(
+        proc_output,
+        proc=proc,
+        cmd_args=cmd_args,
+        # There's no good way to sequence output from multiple processes reliably, so we won't
+        # pretend to be able to.  Only allow one matching process for the comination of proc and
+        # cmd_args
+        strict_proc_matching=True,
+    )[0]
 
     # Get all the output from the process.  This will be a list of strings.  Each string may
     # contain multiple lines of output

--- a/apex_launchtest/apex_launchtest/asserts/assert_sequential_output.py
+++ b/apex_launchtest/apex_launchtest/asserts/assert_sequential_output.py
@@ -55,24 +55,24 @@ class SequentialTextChecker:
 
 @contextmanager
 def assertSequentialStdout(proc_output,
-                           proc,
+                           process,
                            cmd_args=None):
     """
     Create a context manager used to check stdout occured in a specific order.
 
     :param proc_output:  The captured output from a test run
 
-    :param proc: The process whose output will be searched
-    :type proc: A string (search by process name) or a launch.actions.ExecuteProcess object
+    :param process: The process whose output will be searched
+    :type process: A string (search by process name) or a launch.actions.ExecuteProcess object
 
     :param cmd_args: Optional.  If 'proc' is a string, cmd_args will be used to disambiguate
     processes with the same name.  Pass apex_launchtest.asserts.NO_CMD_ARGS to match a proc without
     command arguments
     :type cmd_args: string
     """
-    proc = resolveProcesses(
+    process = resolveProcesses(
         proc_output,
-        proc=proc,
+        process=process,
         cmd_args=cmd_args,
         # There's no good way to sequence output from multiple processes reliably, so we won't
         # pretend to be able to.  Only allow one matching process for the comination of proc and
@@ -82,7 +82,7 @@ def assertSequentialStdout(proc_output,
 
     # Get all the output from the process.  This will be a list of strings.  Each string may
     # contain multiple lines of output
-    to_check = [p.text.decode('ascii') for p in proc_output[proc]]
+    to_check = [p.text.decode() for p in proc_output[process]]
     checker = SequentialTextChecker(to_check)
 
     try:

--- a/apex_launchtest/apex_launchtest/event_handlers/stdout_ready_listener.py
+++ b/apex_launchtest/apex_launchtest/event_handlers/stdout_ready_listener.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+from typing import Text
+
+from launch.actions import ExecuteProcess
 from launch.event_handlers import OnProcessIO
 from launch.some_actions_type import SomeActionsType
 
@@ -25,19 +29,21 @@ class StdoutReadyListener(OnProcessIO):
     bit of text
     """
 
-    def __init__(self,
-                 proc_name,
-                 ready_txt,
-                 actions: [SomeActionsType]):
-        self.__proc_name = proc_name
+    def __init__(
+        self,
+        *,
+        target_action: Optional[ExecuteProcess] = None,
+        ready_txt: Text,
+        actions: [SomeActionsType]
+    ):
         self.__ready_txt = ready_txt
         self.__actions = actions
 
         super().__init__(
+            target_action=target_action,
             on_stdout=self.__on_stdout
         )
 
     def __on_stdout(self, process_io):
-        if self.__proc_name in process_io.process_name:
-            if self.__ready_txt in process_io.text.decode('ascii'):
-                return self.__actions
+        if self.__ready_txt in process_io.text.decode('ascii'):
+            return self.__actions

--- a/apex_launchtest/apex_launchtest/event_handlers/stdout_ready_listener.py
+++ b/apex_launchtest/apex_launchtest/event_handlers/stdout_ready_listener.py
@@ -45,5 +45,5 @@ class StdoutReadyListener(OnProcessIO):
         )
 
     def __on_stdout(self, process_io):
-        if self.__ready_txt in process_io.text.decode('ascii'):
+        if self.__ready_txt in process_io.text.decode():
             return self.__actions

--- a/apex_launchtest/apex_launchtest/io_handler.py
+++ b/apex_launchtest/apex_launchtest/io_handler.py
@@ -48,10 +48,7 @@ class IoHandler:
         :returns [launch.actions.ExecuteProcess]:
         """
         return list(
-            map(
-                lambda x: x.action,
-                [self._process_name_dict[name][0] for name in self._process_name_dict]
-            )
+            [val[0].action for val in self._process_name_dict.values()]
         )
 
     def process_names(self):
@@ -128,7 +125,7 @@ class ActiveIoHandler(IoHandler):
 
     def assertWaitFor(self,
                       msg,
-                      proc=None,  # Will wait for IO from all procs by default
+                      process=None,  # Will wait for IO from all procs by default
                       cmd_args=None,
                       *,
                       strict_proc_matching=True,
@@ -140,7 +137,7 @@ class ActiveIoHandler(IoHandler):
                 assertInStdout(
                     self._io_handler,  # Use unsynchronized, since this is called from a lock
                     msg=msg,
-                    proc=proc,
+                    process=process,
                     cmd_args=cmd_args,
                     strict_proc_matching=strict_proc_matching
                 )
@@ -164,7 +161,7 @@ class ActiveIoHandler(IoHandler):
             # Help the user a little.  It's possible that they gave us a bad process name and no
             # had no hope of matching anything.
             matches = resolveProcesses(self,
-                                       proc=proc,
+                                       process=process,
                                        cmd_args=cmd_args,
                                        strict_proc_matching=False)
             if len(matches) == 0:
@@ -172,7 +169,7 @@ class ActiveIoHandler(IoHandler):
                     "After fimeout, found no processes matching '{}'  "
                     "It either doesn't exist, was never launched, "
                     "or didn't generate any output".format(
-                        proc
+                        process
                     )
                 )
 

--- a/apex_launchtest/apex_launchtest/io_handler.py
+++ b/apex_launchtest/apex_launchtest/io_handler.py
@@ -15,6 +15,8 @@
 import threading
 
 from .asserts.assert_output import assertInStdout
+from .util import NoMatchingProcessException
+from .util import resolveProcesses
 
 
 class IoHandler:
@@ -45,9 +47,11 @@ class IoHandler:
 
         :returns [launch.actions.ExecuteProcess]:
         """
-        return map(
-            lambda x: x.action,
-            [self._process_name_dict[name][0] for name in self._process_name_dict]
+        return list(
+            map(
+                lambda x: x.action,
+                [self._process_name_dict[name][0] for name in self._process_name_dict]
+            )
         )
 
     def process_names(self):
@@ -122,7 +126,13 @@ class ActiveIoHandler(IoHandler):
         with self._sync_lock:
             return self._io_handler[key]
 
-    def assertWaitFor(self, msg, timeout):
+    def assertWaitFor(self,
+                      msg,
+                      proc=None,  # Will wait for IO from all procs by default
+                      cmd_args=None,
+                      *,
+                      strict_proc_matching=True,
+                      timeout=10):
         success = False
 
         def msg_found():
@@ -130,16 +140,13 @@ class ActiveIoHandler(IoHandler):
                 assertInStdout(
                     self._io_handler,  # Use unsynchronized, since this is called from a lock
                     msg=msg,
-                    proc="",           # Will match all process names
-                    cmd_args=None,     # Will match all cmd args
-                    strict_proc_matching=False
+                    proc=proc,
+                    cmd_args=cmd_args,
+                    strict_proc_matching=strict_proc_matching
                 )
                 return True
-            except Exception:
-                # TODO (pete baughman) This is here to handle the case where
-                # _assertInStdoutByStringProcessName raises an exception because no proc has
-                # generated output yet.  Perhaps a more specific exception should be used and
-                # then we catch the specific exception type
+            except NoMatchingProcessException:
+                # This can happen if no processes have generated any output yet.  It's not fatal.
                 return False
             except AssertionError:
                 return False
@@ -152,4 +159,21 @@ class ActiveIoHandler(IoHandler):
                 msg_found,
                 timeout=timeout
             )
+
+        if not success:
+            # Help the user a little.  It's possible that they gave us a bad process name and no
+            # had no hope of matching anything.
+            matches = resolveProcesses(self,
+                                       proc=proc,
+                                       cmd_args=cmd_args,
+                                       strict_proc_matching=False)
+            if len(matches) == 0:
+                raise Exception(
+                    "After fimeout, found no processes matching '{}'  "
+                    "It either doesn't exist, was never launched, "
+                    "or didn't generate any output".format(
+                        proc
+                    )
+                )
+
         assert success, "Wait for msg '{}' timed out".format(msg)

--- a/apex_launchtest/apex_launchtest/proc_info_handler.py
+++ b/apex_launchtest/apex_launchtest/proc_info_handler.py
@@ -101,7 +101,7 @@ class ActiveProcInfoHandler(ProcInfoHandler):
             return self._proc_info_handler[key]
 
     def assertWaitForShutdown(self,
-                              proc,
+                              process,
                               cmd_args=None,
                               *,
                               timeout=10):
@@ -112,7 +112,7 @@ class ActiveProcInfoHandler(ProcInfoHandler):
             try:
                 resolveProcesses(
                     info_obj=self._proc_info_handler,
-                    proc=proc,
+                    process=process,
                     cmd_args=cmd_args,
                     strict_proc_matching=True
                 )
@@ -126,4 +126,4 @@ class ActiveProcInfoHandler(ProcInfoHandler):
                 timeout=timeout
             )
 
-        assert success, "Timed out waiting for process '{}' to finish".format(proc)
+        assert success, "Timed out waiting for process '{}' to finish".format(process)

--- a/apex_launchtest/apex_launchtest/util/__init__.py
+++ b/apex_launchtest/apex_launchtest/util/__init__.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from sys import executable as __executable
 from launch.actions import ExecuteProcess as __ExecuteProcess
+
+from .proc_lookup import NO_CMD_ARGS
+from .proc_lookup import resolveProcesses
+from .proc_lookup import NoMatchingProcessException
 
 
 def KeepAliveProc():
@@ -42,5 +45,10 @@ except KeyboardInterrupt:
 
 
 __all__ = [
+    'resolveProcesses',
+
     'KeepAliveProc',
+    'NoMatchingProcessException',
+
+    'NO_CMD_ARGS',
 ]

--- a/apex_launchtest/apex_launchtest/util/proc_lookup.py
+++ b/apex_launchtest/apex_launchtest/util/proc_lookup.py
@@ -1,0 +1,105 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch.actions
+
+NO_CMD_ARGS = object()
+
+
+class NoMatchingProcessException(Exception):
+    pass
+
+
+def _proc_to_name_and_args(proc):
+    # proc is a launch.actions.ExecuteProcess
+    return "{} {}".format(
+        proc.process_details['name'],
+        " ".join(proc.process_details['cmd'][1:])
+    )
+
+
+def _str_name_to_process(info_obj, proc_name, cmd_args):
+
+    def name_match_fn(proc):
+        return proc_name in proc.process_details['name']
+
+    def cmd_match_fn(proc):
+        if cmd_args is None:
+            return True
+        elif cmd_args is NO_CMD_ARGS:
+            return len(proc.process_details['cmd']) == 1
+        else:
+            return cmd_args in proc.process_details['cmd'][1:]
+
+    matches = [proc for proc in info_obj.processes()
+               if name_match_fn(proc) and cmd_match_fn(proc)]
+
+    return matches
+
+
+def resolveProcesses(info_obj, *, proc=None, cmd_args=None, strict_proc_matching=True):
+    """
+    Resolve a process name and cmd arguments to one or more launch.actions.ExecuteProcess.
+
+    :param info_obj: a ProcInfoHandler or an IoHandler that contains processes that could match
+
+    :returns: A list of matching processes
+    """
+    if proc is None:
+        # We want to search all processes
+        all_procs = info_obj.processes()
+        if len(all_procs) == 0:
+            raise NoMatchingProcessException("No data recorded for any process")
+        return all_procs
+
+    if isinstance(proc, launch.actions.ExecuteProcess):
+        # We want to search a specific process
+        if proc in info_obj.processes():
+            return [proc]
+        else:
+            raise NoMatchingProcessException(
+                "No data recorded for proc {}".format(_proc_to_name_and_args(proc))
+            )
+
+    elif isinstance(proc, str):
+        # We want to search one (or more) processes that match a particular string.  The "or more"
+        # part is controlled by the strict_proc_matching argument
+        matches = _str_name_to_process(info_obj, proc, cmd_args)
+        if len(matches) == 0:
+            names = ', '.join(sorted([_proc_to_name_and_args(p) for p in info_obj.processes()]))
+
+            raise NoMatchingProcessException(
+                "Did not find any processes matching name '{}' and args '{}'. Procs: {}".format(
+                    proc,
+                    cmd_args,
+                    names
+                )
+            )
+
+        if strict_proc_matching and len(matches) > 1:
+            names = ', '.join(sorted([_proc_to_name_and_args(p) for p in info_obj.processes()]))
+            raise Exception(
+                "Found multiple processes matching name '{}' and cmd_args '{}'. Procs: {}".format(
+                    proc,
+                    cmd_args,
+                    names
+                )
+            )
+        return list(matches)
+
+    else:
+        # Invalid argument passed for 'proc'
+        raise TypeError(
+            "proc argument must be 'ExecuteProcess' or 'str' not {}".format(type(proc))
+        )

--- a/apex_launchtest/examples/args.test.py
+++ b/apex_launchtest/examples/args.test.py
@@ -64,7 +64,7 @@ def generate_test_description(ready_fn):
 class TestTerminatingProcessStops(unittest.TestCase):
 
     def test_proc_terminates(self):
-        self.proc_info.assertWaitForShutdown(proc=dut_process, timeout=10)
+        self.proc_info.assertWaitForShutdown(process=dut_process, timeout=10)
 
 
 @apex_launchtest.post_shutdown_test()

--- a/apex_launchtest/examples/args.test.py
+++ b/apex_launchtest/examples/args.test.py
@@ -64,7 +64,7 @@ def generate_test_description(ready_fn):
 class TestTerminatingProcessStops(unittest.TestCase):
 
     def test_proc_terminates(self):
-        self.proc_info.assertWaitForShutdown(process=dut_process, timeout=10)
+        self.proc_info.assertWaitForShutdown(proc=dut_process, timeout=10)
 
 
 @apex_launchtest.post_shutdown_test()

--- a/apex_launchtest/test/test_io_handler_and_assertions.py
+++ b/apex_launchtest/test/test_io_handler_and_assertions.py
@@ -87,7 +87,7 @@ class TestIoHandlerAndAssertions(unittest.TestCase):
         self.assertEqual(3, len(self.proc_output.processes()))
 
     def test_only_one_process_had_arguments(self):
-        text_lines = [t.text.decode('ascii') for t in self.proc_output]
+        text_lines = [t.text.decode() for t in self.proc_output]
         print("All text: {}".format(text_lines))
 
         matches = [t for t in text_lines if "Called with arguments" in t]
@@ -108,7 +108,7 @@ class TestIoHandlerAndAssertions(unittest.TestCase):
 
     def test_EXPECTED_TEXT_is_present(self):
         # Sanity check - makes sure the EXPECTED_TEXT is somewhere in the test run
-        text_lines = [t.text.decode('ascii') for t in self.proc_output]
+        text_lines = [t.text.decode() for t in self.proc_output]
         contains_ready = [self.EXPECTED_TEXT in t for t in text_lines]
         self.assertTrue(any(contains_ready))
 


### PR DESCRIPTION
  - Gave all of these methods similar signatures.  They can all take ExecuteProcess actions or strings to identify a process
  - New util to handle the lookup of process actions in one place

New file is apex_launchtest/util/proc_lookup.py.  All of the other assert methods use this to translate strings into ExecuteProcess actions.  AssertInStdout was the most 'advanced' assert, so most of the logic in proc_lookup was taken from there

#### Bugfix
 - While testing this, I also found a bug in proc_info_handler.py.  A method name was wrong, and it had parenthesis in the wrong place

#### Closes
 - https://github.com/ApexAI/apex_rostest/issues/7