### PR TITLE
Remove rclpy from apex_launch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ build_isolated:
       --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
     # Make sure we can build and test apex_launchtest
     - colcon list --topological-graph --packages-up-to apex_launchtest
-    # - colcon list --topological-graph --packages-up-to apex_launchtest | grep "rclpy" &> /dev/null && exit 1  # Fail if apex_launchtest depends on rclpy
+    - colcon list --topological-graph --packages-up-to apex_launchtest | grep "rclpy" &> /dev/null && exit 1  # Fail if apex_launchtest depends on rclpy
     - colcon build --packages-up-to apex_launchtest
     - tar -cf launchtest_artifacts.tar build install
     # Make sure we can also build and test apex_launchtest_ros

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,17 @@ build_all:
       - build
       - install
 
+build_all_crystal:
+  <<: *bin_job_template
+  image: osrf/ros:crystal-desktop
+  stage: build
+  script:
+    - colcon build --symlink-install
+  artifacts:
+    paths:
+      - build
+      - install
+
 # Build everything from source to make sure our package.xml deps are correct
 build_isolated:
   <<: *src_job_template
@@ -134,6 +145,21 @@ test_all:
       - log
       - "*/.coverage"
 
+test_all_crystal:
+  <<: *bin_job_template
+  image: osrf/ros:crystal-desktop
+  stage: test
+  dependencies:
+    - build_all_crystal
+  script:
+    - pip3 install mock
+    - colcon test
+    - colcon test-result --verbose
+  artifacts:
+    when: always
+    paths:
+      - log
+
 test_isolated:
   <<: *src_job_template
   stage: test
@@ -157,7 +183,6 @@ coverage:
     name: python:3.6
   dependencies:
     - test_all
-  before_script: []  # Don't need ROS setup for the coverage job
   script:
     - pip3 install coverage
     - find . -iname ".coverage" -exec coverage combine -a {} \;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,16 +3,54 @@ stages:
   - test
   - report
 
-before_script:
-  - echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
-  - curl http://repo.ros2.org/repos.key | apt-key add -
-  - apt-get update
-  - apt-get install -y python3-colcon-common-extensions
-  - source /opt/ros/crystal/setup.bash
+# Template for jobs that overlay on top of ROS binaries
+.job_template: &bin_job_template
+  image: osrf/ros2:nightly
+  before_script:
+    - echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
+    - curl http://repo.ros2.org/repos.key | apt-key add -
+    - apt-get update
+    - apt-get install -y python3-colcon-common-extensions
+    - source /opt/ros/crystal/setup.bash
+
+# Template for jobs that want to build everything from source (much slower)
+.job_template: &src_job_template
+  image: osrf/ros2:nightly
+  before_script:
+    - apt-get update && apt-get install -y 
+      build-essential 
+      cmake 
+      git 
+      python3-colcon-common-extensions 
+      python3-pip 
+      python-rosdep 
+      python3-vcstool 
+      wget
+    - python3 -m pip install -U 
+      argcomplete 
+      flake8 
+      flake8-blind-except 
+      flake8-builtins 
+      flake8-class-newline 
+      flake8-comprehensions 
+      flake8-deprecated 
+      flake8-docstrings 
+      flake8-import-order 
+      flake8-quotes 
+      git+https://github.com/lark-parser/lark.git@0.7d 
+      pytest-repeat 
+      pytest-rerunfailures 
+      pytest 
+      pytest-cov 
+      pytest-runner 
+      setuptools
+    - apt-get install --no-install-recommends -y 
+      libasio-dev 
+      libtinyxml2-dev
 
 build_launchtest:
+  <<: *bin_job_template
   stage: build
-  image: osrf/ros2:nightly
   script:
     - colcon build --packages-up-to apex_launchtest apex_launchtest_cmake
   artifacts:
@@ -21,8 +59,8 @@ build_launchtest:
       - install 
 
 build_all:
+  <<: *bin_job_template
   stage: build
-  image: osrf/ros2:nightly
   script:
     - colcon build --symlink-install
   artifacts:
@@ -30,9 +68,44 @@ build_all:
       - build
       - install
 
+# Build everything from source to make sure our package.xml deps are correct
+build_isolated:
+  <<: *src_job_template
+  stage: build
+  image:
+    name: osrf/ros2:nightly
+    entrypoint: [""]
+  only:
+    - schedules
+  script:
+    - env  # For debugging
+    - mkdir upstream_src
+    - wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+    - vcs import upstream_src < ros2.repos
+    - rosdep update
+    - rosdep install
+      --from-paths upstream_src
+      --ignore-src
+      --rosdistro crystal
+      -y
+      --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
+    # Make sure we can build and test apex_launchtest
+    - colcon list --topological-graph --packages-up-to apex_launchtest
+    # - colcon list --topological-graph --packages-up-to apex_launchtest | grep "rclpy" &> /dev/null && exit 1  # Fail if apex_launchtest depends on rclpy
+    - colcon build --packages-up-to apex_launchtest
+    - tar -cf launchtest_artifacts.tar build install
+    # Make sure we can also build and test apex_launchtest_ros
+    - colcon list --topological-graph --packages-up-to apex_launchtest_ros
+    - colcon build --packages-up-to apex_launchtest_ros
+    - tar -cf launchtest_ros_artifacts.tar build install
+  artifacts:
+    paths:
+      - launchtest_artifacts.tar
+      - launchtest_ros_artifacts.tar
+
 test_launchtest:
+  <<: *bin_job_template
   stage: test
-  image: osrf/ros2:nightly
   dependencies:
     - build_launchtest
   script:
@@ -45,8 +118,8 @@ test_launchtest:
       - log
 
 test_all:
+  <<: *bin_job_template
   stage: test
-  image: osrf/ros2:nightly
   dependencies:
     - build_all
   script:
@@ -60,6 +133,23 @@ test_all:
       - install
       - log
       - "*/.coverage"
+
+test_isolated:
+  <<: *src_job_template
+  stage: test
+  image: osrf/ros2:nightly
+  only:
+    - schedules
+  dependencies:
+    - build_isolated
+  script:
+    - pip3 install mock
+    - tar xf launchtest_artifacts.tar -C .
+    - colcon test --packages-select apex_launchtest --pytest-args "-k not (test_flake8 or test_pep257)"
+    - colcon test-result --all --verbose
+    - tar xf launchtest_ros_artifacts.tar -C .
+    - colcon test --packages-select apex_launchtest_ros --pytest-args "-k not (test_flake8 or test_pep257)"
+    - colcon test-result --all --verbose
 
 coverage:
   stage: report

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It works similarly to rostest, but makes it easier to inspect the processes unde
   * Some tests run concurrently with the launch and can interact with the running processes.
 
 ## Compatibility
-Designed to work with [ros2 crystal](https://index.ros.org/doc/ros2/Installation/), but requires a slightly newer version of [launch](https://github.com/ros2/launch).  Use the commit [300196b15b0aa99c045460e7d81333df99b8f8da](https://github.com/ros2/launch/tree/300196b15b0aa99c045460e7d81333df99b8f8da) or newer.
+Designed to work with [ros2 crystal](https://index.ros.org/doc/ros2/Installation/)
 
 ## Quick start example
 Start with the apex_launchtest example [good_proc.test.py](apex_launchtest/examples/good_proc.test.py).  Run the example by doing

--- a/apex_launchtest/apex_launchtest/apex_launchtest_main.py
+++ b/apex_launchtest/apex_launchtest/apex_launchtest_main.py
@@ -18,10 +18,9 @@ from importlib.machinery import SourceFileLoader
 import os
 import sys
 
-from ros2launch.api import print_arguments_of_launch_description
-
 from .apex_runner import ApexRunner
 from .junitxml import unittestResultsToXml
+from .print_arguments import print_arguments_of_launch_description
 
 _logger_ = logging.getLogger(__name__)
 

--- a/apex_launchtest/apex_launchtest/print_arguments.py
+++ b/apex_launchtest/apex_launchtest/print_arguments.py
@@ -1,0 +1,39 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def print_arguments_of_launch_description(*, launch_description):
+    """Print the arguments of a LaunchDescription to the console."""
+    print("Arguments (pass arguments as '<name>:=<value>'):")
+    launch_arguments = launch_description.get_launch_arguments()
+    any_conditional_arguments = False
+    for argument_action in launch_arguments:
+        msg = "\n    '"
+        msg += argument_action.name
+        msg += "':"
+        if argument_action._conditionally_included:
+            any_conditional_arguments = True
+            msg += '*'
+        msg += '\n        '
+        msg += argument_action.description
+        if argument_action.default_value is not None:
+            default_str = ' + '.join([token.describe() for token in argument_action.default_value])
+            msg += '\n        (default: {})'.format(default_str)
+        print(msg)
+
+    if len(launch_arguments) > 0:
+        if any_conditional_arguments:
+            print('\n* argument(s) which are only used if specific conditions occur')
+    else:
+        print('\n  No arguments.')

--- a/apex_launchtest/package.xml
+++ b/apex_launchtest/package.xml
@@ -8,7 +8,6 @@
   <license>Apache License 2.0</license>
 
   <exec_depend>launch</exec_depend>
-  <exec_depend>ros2launch</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/apex_launchtest/test/test_print_arguments.py
+++ b/apex_launchtest/test/test_print_arguments.py
@@ -1,0 +1,66 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+
+import ament_index_python
+
+
+# Run the 'args.test.py' example with --show-args and verify the arguments are printed
+# but the test does not run
+def test_print_args():
+
+    testpath = os.path.join(
+        ament_index_python.get_package_share_directory('apex_launchtest'),
+        'examples',
+        'args.test.py',
+    )
+
+    completed_process = subprocess.run(
+        args=[
+            'apex_launchtest',
+            testpath,
+            '--show-args',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert 0 == completed_process.returncode
+    # Take a look at examples/args.test.py to see where this expected output comes from
+    assert 'dut_arg' in completed_process.stdout.decode()
+    assert 'Passed to the terminating process' in completed_process.stdout.decode()
+
+
+def test_no_args_to_print():
+
+    testpath = os.path.join(
+        ament_index_python.get_package_share_directory('apex_launchtest'),
+        'examples',
+        'good_proc.test.py',
+    )
+
+    completed_process = subprocess.run(
+        args=[
+            'apex_launchtest',
+            testpath,
+            '--show-args',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert 0 == completed_process.returncode
+    assert 'No arguments.' in completed_process.stdout.decode()


### PR DESCRIPTION
 - Take out dependency on ros2launch API
 - Add CI job that will run nightly and fail if rclpy gets introduced as a dependency
 - Add a job to make sure we stay compatible with ros-crystal
 - Add a test for the new copy/pasted 'print arguments' functionality

#### Note for Reviewer
We're compatible with ROS crystal now!  The README.md has been updated accordingly

This PR addresses https://github.com/ApexAI/apex_rostest/issues/14

Look at this CI pipeline to see the 'isloated' build and test job run (from before I changed it to 'scheduled only': https://gitlab.com/ApexAI/apex_rostest/pipelines/50254676

