### PR TITLE
Add ability to pass objects from test_description to tests

### DIFF
--- a/apex_launchtest/examples/README.md
+++ b/apex_launchtest/examples/README.md
@@ -37,6 +37,5 @@ Usage:
 > apex_launchtest examples/example_test_context.test.py
 
 This example shows how the `generate_test_description` function can return a tuple where the second
-item is a dictionary of objects that will be injected into the individual test cases.  Notice how
-test_process_output uses the stored dut from the test description, and how test_int_val retreives the
-int_val.
+item is a dictionary of objects that will be injected into the individual test cases.  Tests that
+wish to use elements of the test context can add arguments with names matching the keys of the dictionary.

--- a/apex_launchtest/examples/README.md
+++ b/apex_launchtest/examples/README.md
@@ -30,3 +30,13 @@ in the launch description via a launch.substitutions.LaunchConfiguration.  The a
 available to the test cases via a self.test_args dictionary
 
 This example will fail if no arguments are passed.
+
+## `example_test_context.test.py`
+
+Usage:
+> apex_launchtest examples/example_test_context.test.py
+
+This example shows how the `generate_test_description` function can return a tuple where the second
+item is a dictionary of objects that will be injected into the individual test cases.  Notice how
+test_process_output uses the stored dut from the test description, and how test_int_val retreives the
+int_val.

--- a/apex_launchtest/examples/example_test_context.test.py
+++ b/apex_launchtest/examples/example_test_context.test.py
@@ -63,8 +63,9 @@ def generate_test_description(ready_fn):
 class TestProcOutput(unittest.TestCase):
 
     def test_process_output(self, dut):
-        # self.dut below was added to the test case because it was part of the test context
-        # returned by generate_test_description
+        # We can use the 'dut' argument here because it's part of the test context
+        # returned by `generate_test_description`  It's not necessary for every
+        # test to use every piece of the context
         self.proc_output.assertWaitFor("Loop 1", process=dut, timeout=10)
 
 
@@ -72,14 +73,19 @@ class TestProcOutput(unittest.TestCase):
 class TestProcessOutput(unittest.TestCase):
 
     def test_full_output(self, dut):
+        # Same as the test_process_output test.  apex_launchtest binds the value of
+        # 'dut' from the test_context to the test before it runs
         with assertSequentialStdout(self.proc_output, process=dut) as cm:
             cm.assertInStdout("Starting Up")
             cm.assertInStdout("Shutting Down")
 
     def test_int_val(self, int_val):
+        # Arguments don't have to be part of the LaunchDescription.  Any object can
+        # be passed in
         self.assertEqual(int_val, 10)
 
     def test_all_context_objects(self, int_val, dut):
+        # Multiple arguments are supported
         self.assertEqual(int_val, 10)
         self.assertIn("good_proc", dut.process_details['name'])
 

--- a/apex_launchtest/examples/example_test_context.test.py
+++ b/apex_launchtest/examples/example_test_context.test.py
@@ -1,0 +1,80 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+import ament_index_python
+import launch
+import launch.actions
+
+import apex_launchtest
+from apex_launchtest.asserts import assertSequentialStdout
+
+
+TEST_PROC_PATH = os.path.join(
+    ament_index_python.get_package_prefix('apex_launchtest'),
+    'lib/apex_launchtest',
+    'good_proc'
+)
+
+
+# This launch description shows the prefered way to let the tests access launch actions.  By
+# adding them to the test context, it's not necessary to scope them at the module level like in
+# the good_proc.test.py example
+def generate_test_description(ready_fn):
+    # This is necessary to get unbuffered output from the process under test
+    proc_env = os.environ.copy()
+    proc_env["PYTHONUNBUFFERED"] = "1"
+
+    dut_process = launch.actions.ExecuteProcess(
+        cmd=[TEST_PROC_PATH],
+        env=proc_env,
+    )
+
+    ld = launch.LaunchDescription([
+        dut_process,
+
+        # Start tests right away - no need to wait for anything
+        launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+    ])
+
+    # Items in this dictionary will be added to the test cases as an attribute based on
+    # dictionary key
+    test_context = {
+        "dut": dut_process,
+        "int_val": 10
+    }
+
+    return ld, test_context
+
+
+class TestProcOutput(unittest.TestCase):
+
+    def test_process_output(self):
+        # self.dut below was added to the test case because it was part of the test context
+        # returned by generate_test_description
+        self.proc_output.assertWaitFor("Loop 1", process=self.dut, timeout=10)
+
+
+@apex_launchtest.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+
+    def test_full_output(self):
+        with assertSequentialStdout(self.proc_output, process=self.dut) as cm:
+            cm.assertInStdout("Starting Up")
+            cm.assertInStdout("Shutting Down")
+
+    def test_int_val(self):
+        self.assertEqual(self.int_val, 10)

--- a/apex_launchtest/examples/example_test_context.test.py
+++ b/apex_launchtest/examples/example_test_context.test.py
@@ -62,19 +62,28 @@ def generate_test_description(ready_fn):
 
 class TestProcOutput(unittest.TestCase):
 
-    def test_process_output(self):
+    def test_process_output(self, dut):
         # self.dut below was added to the test case because it was part of the test context
         # returned by generate_test_description
-        self.proc_output.assertWaitFor("Loop 1", process=self.dut, timeout=10)
+        self.proc_output.assertWaitFor("Loop 1", process=dut, timeout=10)
 
 
 @apex_launchtest.post_shutdown_test()
 class TestProcessOutput(unittest.TestCase):
 
-    def test_full_output(self):
-        with assertSequentialStdout(self.proc_output, process=self.dut) as cm:
+    def test_full_output(self, dut):
+        with assertSequentialStdout(self.proc_output, process=dut) as cm:
             cm.assertInStdout("Starting Up")
             cm.assertInStdout("Shutting Down")
 
-    def test_int_val(self):
-        self.assertEqual(self.int_val, 10)
+    def test_int_val(self, int_val):
+        self.assertEqual(int_val, 10)
+
+    def test_all_context_objects(self, int_val, dut):
+        self.assertEqual(int_val, 10)
+        self.assertIn("good_proc", dut.process_details['name'])
+
+    def test_all_context_objects_different_order(self, dut, int_val):
+        # Put the arguments in a different order from the above test
+        self.assertEqual(int_val, 10)
+        self.assertIn("good_proc", dut.process_details['name'])


### PR DESCRIPTION
### Description
To facilitate writing test factories (and to clean up the module scope of tests a little bit), we need a way to pass information from the `generate_test_description` function over to the tests.  Previously you could do this by [declaring things at the module level](https://github.com/ApexAI/apex_rostest/blob/master/apex_launchtest/examples/good_proc.test.py#L36-L39) but that's a little gross, and it doesn't make it very easy to write a factory class that makes test descriptions and automatically makes the corresponding tests that go along with.

To make this cleaner, the generate_test_description function can optionally return a second object - a dictionary.  ~~Each item in the dictionary will be injected into the individual tests as though the object was an attribute with the same name as the dictionary key.~~  Each item in the dictionary will be passed to the individual test cases if they're declared with an argument with the same name.

This will let us write factory methods that return a complicated launch descriptions and pass parts of the complicated launch description transparently to factory tests.

#### Notes for Reviewers
I left good_proc.test.py the way it was because the examples are also test cases, and I want to make sure we don't regress the case where a test description only returns one object

example_test_context.test.py shows the new functionality, and has some simple tests that use the launch context

#### Todo:
 - ~~_bind_test_context_to_tests should make sure the attribute name doesn't already exist so we're not overwriting important test functionality.  This should probably be an error~~
 - [x] Merge https://github.com/ApexAI/apex_rostest/pull/22 and rebase this branch, then change the PR to target master