### PR TITLE
BUG-Fix FailResult not serializing to XML

### DIFF
--- a/apex_launchtest/apex_launchtest/apex_runner.py
+++ b/apex_launchtest/apex_launchtest/apex_runner.py
@@ -27,14 +27,7 @@ from ros2launch.api.api import parse_launch_arguments
 from .io_handler import ActiveIoHandler
 from .loader import PostShutdownTestLoader, PreShutdownTestLoader
 from .proc_info_handler import ActiveProcInfoHandler
-from .test_result import TestResult
-
-
-class _fail_result(unittest.TestResult):
-    """For test runs that fail when the DUT dies unexpectedly."""
-
-    def wasSuccessful(self):
-        return False
+from .test_result import FailResult, TestResult
 
 
 class ApexRunner(object):
@@ -119,7 +112,7 @@ class ApexRunner(object):
             print("Processes under test stopped before tests completed")
             self._print_process_output_summary()  # <-- Helpful to debug why processes died early
             # We treat this as a test failure and return some test results indicating such
-            return _fail_result(), _fail_result()
+            return FailResult(), FailResult()
 
         # Now, run the post-shutdown tests
         inactive_suite = PostShutdownTestLoader().loadTestsFromModule(self._test_module)

--- a/apex_launchtest/apex_launchtest/test_result.py
+++ b/apex_launchtest/apex_launchtest/test_result.py
@@ -17,6 +17,22 @@ import time
 import unittest
 
 
+class FailResult(unittest.TestResult):
+    """For test runs that fail when the DUT dies unexpectedly."""
+
+    @property
+    def testCases(self):
+        return []
+
+    @property
+    def testTimes(self):
+        """Get a dict of {test_case: elapsed_time}."""
+        return {}
+
+    def wasSuccessful(self):
+        return False
+
+
 class TestResult(unittest.TextTestResult):
     """
     Subclass of unittest.TestResult that collects more information about the tests that ran.

--- a/apex_launchtest/test/test_xml_output.py
+++ b/apex_launchtest/test/test_xml_output.py
@@ -20,6 +20,9 @@ import xml.etree.ElementTree as ET
 
 import ament_index_python
 
+from apex_launchtest.test_result import FailResult
+from apex_launchtest.junitxml import unittestResultsToXml
+
 
 class TestGoodXmlOutput(unittest.TestCase):
 
@@ -58,3 +61,19 @@ class TestGoodXmlOutput(unittest.TestCase):
         # Expecting an element called "active_tests" and "after_shutdown_tests"
         child_names = [chld.attrib['name'] for chld in root.getchildren()]
         self.assertEqual(set(child_names), set(['active_tests', 'after_shutdown_tests']))
+
+
+class TestXmlFunctions(unittest.TestCase):
+    # This are closer to unit tests - just call the functions that generate XML
+
+    def test_fail_results_serialize(self):
+        xml_tree = unittestResultsToXml(
+            name="fail_xml",
+            test_results={
+                "active_tests": FailResult()
+            }
+        )
+
+        # Simple sanity check - see that there's a child element called active_tests
+        child_names = [chld.attrib['name'] for chld in xml_tree.getroot().getchildren()]
+        self.assertEqual(set(child_names), set(['active_tests']))


### PR DESCRIPTION
 - Give FailResult the VIP treatment by giving it the extra properties that
   the TestResult class has.
 - Add a new test that we can run a FailResult through our XML serializer


#### Fixes
https://github.com/ApexAI/apex_rostest/issues/24