### PR TITLE
Add coverage on 0% covered files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -189,8 +189,8 @@ coverage:
   script:
     - pip3 install coverage
     - find . -iname ".coverage" -exec coverage combine -a {} \;
-    - coverage report --include=apex_launchtest*
-    - coverage html --include=apex_launchtest*
+    - coverage report
+    - coverage html
   coverage: '/TOTAL\s+\d+\s+\d+\s+(\d+\%)/'
   artifacts:
     paths:

--- a/apex_launchtest/setup.cfg
+++ b/apex_launchtest/setup.cfg
@@ -1,0 +1,4 @@
+[coverage:run]
+    # This will let coverage find files with 0% coverage (not hit by tests at all)
+    source = .
+    omit = setup.py

--- a/apex_launchtest_ros/setup.cfg
+++ b/apex_launchtest_ros/setup.cfg
@@ -1,0 +1,4 @@
+[coverage:run]
+    # This will let coverage find files with 0% coverage (not hit by tests at all)
+    source = .
+    omit = setup.py


### PR DESCRIPTION
Use the 'source' option for coverage to pick up files not touched by any test.  Currently, message_pump and apex_launchtest_ros/__init__.py because we're not running any of the ROS examples.

Information about how this works can be found here: https://coverage.readthedocs.io/en/coverage-4.4.2/source.html

This PR will drop the reported coverage a bit because we're picking up two new files that weren't noticed before:
```
Name                                                            Stmts   Miss  Cover
-----------------------------------------------------------------------------------
. . .
apex_launchtest_ros/apex_launchtest_ros/__init__.py                 2      2     0%
apex_launchtest_ros/apex_launchtest_ros/message_pump.py            17     17     0%
. . .
```

Master coverage looks like this:
```
Name                                                            Stmts   Miss  Cover
-----------------------------------------------------------------------------------
TOTAL                                                             829     44    95%
```
After this PR it will look like this:
```
Name                                                            Stmts   Miss  Cover
-----------------------------------------------------------------------------------
TOTAL                                                             848     63    93%
```

Here's a link to the 'coverage' job for this PR https://gitlab.com/ApexAI/apex_rostest/-/jobs/173878129