### PR TITLE
Fix rclpy dep (again)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,8 +95,8 @@ build_all_crystal:
 build_isolated:
   <<: *src_job_template
   stage: build
-  # only:
-  #   - schedules
+  only:
+    - schedules
   script:
     - env  # For debugging
     # Make sure we can build and test apex_launchtest
@@ -162,8 +162,8 @@ test_all_crystal:
 test_isolated:
   <<: *src_job_template
   stage: test
-  # only:
-  #   - schedules
+  only:
+    - schedules
   dependencies:
     - build_isolated
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,9 @@ stages:
 
 # Template for jobs that want to build everything from source (much slower)
 .job_template: &src_job_template
-  image: osrf/ros2:nightly
+  image:
+    name: osrf/ros2:nightly
+    entrypoint: [""]
   before_script:
     - apt-get update && apt-get install -y 
       build-essential 
@@ -47,6 +49,16 @@ stages:
     - apt-get install --no-install-recommends -y 
       libasio-dev 
       libtinyxml2-dev
+    - mkdir upstream_src
+    - wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+    - vcs import upstream_src < ros2.repos
+    - rosdep update
+    - rosdep install
+      --from-paths upstream_src
+      --ignore-src
+      --rosdistro crystal
+      -y
+      --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
 
 build_launchtest:
   <<: *bin_job_template
@@ -83,23 +95,10 @@ build_all_crystal:
 build_isolated:
   <<: *src_job_template
   stage: build
-  image:
-    name: osrf/ros2:nightly
-    entrypoint: [""]
-  only:
-    - schedules
+  # only:
+  #   - schedules
   script:
     - env  # For debugging
-    - mkdir upstream_src
-    - wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
-    - vcs import upstream_src < ros2.repos
-    - rosdep update
-    - rosdep install
-      --from-paths upstream_src
-      --ignore-src
-      --rosdistro crystal
-      -y
-      --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
     # Make sure we can build and test apex_launchtest
     - colcon list --topological-graph --packages-up-to apex_launchtest
     - colcon list --topological-graph --packages-up-to apex_launchtest | grep "rclpy" &> /dev/null && exit 1  # Fail if apex_launchtest depends on rclpy
@@ -163,12 +162,12 @@ test_all_crystal:
 test_isolated:
   <<: *src_job_template
   stage: test
-  image: osrf/ros2:nightly
-  only:
-    - schedules
+  # only:
+  #   - schedules
   dependencies:
     - build_isolated
   script:
+    - env  # For debugging
     - pip3 install mock
     - tar xf launchtest_artifacts.tar -C .
     - colcon test --packages-select apex_launchtest --pytest-args "-k not (test_flake8 or test_pep257)"
@@ -176,6 +175,10 @@ test_isolated:
     - tar xf launchtest_ros_artifacts.tar -C .
     - colcon test --packages-select apex_launchtest_ros --pytest-args "-k not (test_flake8 or test_pep257)"
     - colcon test-result --all --verbose
+  artifacts:
+    when: always
+    paths:
+      - log
 
 coverage:
   stage: report

--- a/apex_launchtest/apex_launchtest/apex_runner.py
+++ b/apex_launchtest/apex_launchtest/apex_runner.py
@@ -22,10 +22,10 @@ from launch import LaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.event_handlers import OnProcessIO
-from ros2launch.api.api import parse_launch_arguments
 
 from .io_handler import ActiveIoHandler
 from .loader import PostShutdownTestLoader, PreShutdownTestLoader
+from .parse_arguments import parse_launch_arguments
 from .proc_info_handler import ActiveProcInfoHandler
 from .test_result import FailResult, TestResult
 

--- a/apex_launchtest/apex_launchtest/parse_arguments.py
+++ b/apex_launchtest/apex_launchtest/parse_arguments.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+from typing import List
+from typing import Text
+from typing import Tuple
+
+
+# This was copy/pasted from ros2launch.api to avoid a rclpy dependency in apex_launchtest
+def parse_launch_arguments(launch_arguments: List[Text]) -> List[Tuple[Text, Text]]:
+    """Parse the given launch arguments from the command line, into list of tuples for launch."""
+    parsed_launch_arguments = OrderedDict()  # type: ignore
+    for argument in launch_arguments:
+        count = argument.count(':=')
+        if count == 0 or argument.startswith(':=') or (count == 1 and argument.endswith(':=')):
+            raise RuntimeError(
+                "malformed launch argument '{}', expected format '<name>:=<value>'"
+                .format(argument))
+        name, value = argument.split(':=', maxsplit=1)
+        parsed_launch_arguments[name] = value  # last one wins is intentional
+    return parsed_launch_arguments.items()


### PR DESCRIPTION
My previous attempt at detecting accidental rclpy dependencies was a failure.

#### The problem
in the test_isolated job, the osrf/ros2:nightly docker image was sourcing /opt/ros/crystal/setup.bash automatically, so the test job was using dependencies from outside of the isolated install directory

#### Note for reviewer
The three commits here each show one stage of the fix. 
  * 82679a0 - This commit fixes the .gitlab-ci.yml file and makes build_isolated and test_isolated jobs run all the time.  Take a look at [the full pipeline here](https://gitlab.com/ApexAI/apex_rostest/pipelines/51881420).  If you look at [the test logs](https://gitlab.com/ApexAI/apex_rostest/-/jobs/177812022/artifacts/file/log/test_2019-03-14_16-32-41/apex_launchtest/stdout_stderr.log) you can see that the test failed because ros2launch was not found (imported in apex_runner)
```
==================================== ERRORS ====================================
_____________ ERROR collecting test/test_apex_runner_validation.py _____________
ImportError while importing test module '/builds/ApexAI/apex_rostest/apex_launchtest/test/test_apex_runner_validation.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
test/test_apex_runner_validation.py:17: in <module>
    from apex_launchtest.apex_runner import ApexRunner
apex_launchtest/apex_runner.py:25: in <module>
    from ros2launch.api.api import parse_launch_arguments
E   ModuleNotFoundError: No module named 'ros2launch'
_________________ ERROR collecting test/test_runner_results.py _________________
ImportError while importing test module '/builds/ApexAI/apex_rostest/apex_launchtest/test/test_runner_results.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
test/test_runner_results.py:23: in <module>
    from apex_launchtest.apex_runner import ApexRunner
apex_launchtest/apex_runner.py:25: in <module>
    from ros2launch.api.api import parse_launch_arguments
E   ModuleNotFoundError: No module named 'ros2launch'
- generated xml file: /builds/ApexAI/apex_rostest/build/apex_launchtest/pytest.xml -
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
==================== 2 deselected, 2 error in 0.82 seconds =====================
```
  * ea8dd53 - This commit gets rid of the ros2launch dependency.  This [pipeline passes](https://gitlab.com/ApexAI/apex_rostest/pipelines/51892355)
  * 4e28ccd - This commit sets the build_isolated and test_isolated jobs back to "scheduled only."  Notice that these jobs are [missing from the pipeline](https://gitlab.com/ApexAI/apex_rostest/pipelines/51910964)