### PR TITLE
Apply internal fixes and improvements to public repo

### DIFF
--- a/apex_launchtest/apex_launchtest/apex_runner.py
+++ b/apex_launchtest/apex_launchtest/apex_runner.py
@@ -206,6 +206,9 @@ class ApexRunner(object):
         for process in failed_procs:
             print("Process '{}' exited with {}".format(process.process_name, process.returncode))
             print("##### '{}' output #####".format(process.process_name))
-            for io in self.proc_output[process.action]:
-                print("{}".format(io.text.decode('ascii')))
+            try:
+                for io in self.proc_output[process.action]:
+                    print("{}".format(io.text.decode('ascii')))
+            except KeyError:
+                pass  # Process generated no output
             print("#" * (len(process.process_name) + 21))

--- a/apex_launchtest/example_processes/exit_code_proc
+++ b/apex_launchtest/example_processes/exit_code_proc
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import time
+
+
+# This process pretends to do some simple setup, then pretends to do some simple work,
+# then shuts itself down automatically
+if __name__ == "__main__":
+
+    if "--silent" in sys.argv[1:]:
+        sys.exit(1)
+
+    if '--exception' in sys.argv[1:]:
+        raise Exception("Process had a pretend error")
+
+    print("Exiting with a code")
+    sys.exit(1) 

--- a/apex_launchtest/test/test_runner_results.py
+++ b/apex_launchtest/test/test_runner_results.py
@@ -70,9 +70,21 @@ def test_dut_that_has_exception(capsys):
             'terminating_proc'
         )
 
+        EXIT_PROC_PATH = os.path.join(
+            ament_index_python.get_package_prefix('apex_launchtest'),
+            'lib/apex_launchtest',
+            'exit_code_proc'
+        )
+
         return launch.LaunchDescription([
             launch.actions.ExecuteProcess(
                 cmd=[TEST_PROC_PATH, '--exception']
+            ),
+
+            # This process makes sure we can handle processes that exit with a code but don't
+            # generate any output.  This is a regression test for an issue fixed in PR31
+            launch.actions.ExecuteProcess(
+                cmd=[EXIT_PROC_PATH, '--silent']
             ),
 
             launch.actions.OpaqueFunction(function=lambda context: ready_fn()),

--- a/apex_launchtest_cmake/cmake/add_apex_launchtest.cmake
+++ b/apex_launchtest_cmake/cmake/add_apex_launchtest.cmake
@@ -52,9 +52,21 @@
 #
 # :param file: The apex_launchtest test file containing the test to run
 # :type file: string
+# :param TIMEOUT: The test timeout in seconds
+# :type TIMEOUT: integer
+# :param ARGS: Launch arguments to pass to apex_launchtest
+# :type ARGS: string
 function(add_apex_launchtest file)
 
-  cmake_parse_arguments(_add_apex_launchtest "" "" "ARGS" ${ARGN})
+  cmake_parse_arguments(_add_apex_launchtest
+    ""
+    "TIMEOUT"
+    "ARGS"
+    ${ARGN})
+
+  if(NOT _add_apex_launchtest_TIMEOUT)
+    set(_add_apex_launchtest_TIMEOUT 60)
+  endif()
 
   set(_file_name _file_name-NOTFOUND)
   if(IS_ABSOLUTE ${file})
@@ -92,6 +104,7 @@ function(add_apex_launchtest file)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/apex_launchtest/CHANGEME.txt"
     RESULT_FILE "${result_file}"
+    TIMEOUT "${_add_apex_launchtest_TIMEOUT}"
   )
 
 endfunction()

--- a/apex_launchtest_ros/apex_launchtest_ros/message_pump.py
+++ b/apex_launchtest_ros/apex_launchtest_ros/message_pump.py
@@ -15,18 +15,20 @@
 import threading
 
 import rclpy
+import rclpy.executors
 
 
 class MessagePump:
     """Calls rclpy.spin on a thread so tests don't need to."""
 
-    def __init__(self, node):
+    def __init__(self, node, context=None):
         self._node = node
         self._thread = threading.Thread(
             target=self._run,
             name="msg_pump_thread",
         )
         self._run = True
+        self._context = context
 
     def start(self):
         self._thread.start()
@@ -38,5 +40,7 @@ class MessagePump:
             raise Exception("Timed out waiting for message pump to stop")
 
     def _run(self):
+        executor = rclpy.executors.SingleThreadedExecutor(context=self._context)
+        executor.add_node(self._node)
         while self._run:
-            rclpy.spin_once(self._node, timeout_sec=1.0)
+            executor.spin_once(timeout_sec=1.0)


### PR DESCRIPTION
I just sync'd apex_launchtest from github into our internal repo, and these three commits represent places where our internal repo was ahead of the public apex_rostest

 - 9520c7c - This same change is in https://github.com/ApexAI/apex_rostest/pull/29
 - abf801d - If you have a long running test that takes more than 60 seconds, you need to give a longer timeout to ament_add_test.  This commit plumbs that argument up to the add_apex_rostest cmake macro
  - 9ca67ef - This was a for-real bug.  When we try to print extra information when the processes under test die out from under us, the code would fail if one or more of the processes generated no output.

### TODO
- [x] Add a regression test for the issue fixed in 9ca67ef.  Right now the `except KeyError:` part below is not covered.  A regression test will cover these lines
    ```python
    def _print_process_output_summary(self): 
        failed_procs = [proc for proc in self.proc_info if proc.returncode != 0] 
 
        for process in failed_procs: 
            print("Process '{}' exited with {}".format(process.process_name, process.returncode)) 
            print("##### '{}' output #####".format(process.process_name)) 
            try: 
                for io in self.proc_output[process.action]: 
                    print("{}".format(io.text.decode('ascii'))) 
            except KeyError: 
                pass  # Process generated no output 
            print("#" * (len(process.process_name) + 21)) 
    ```