### PR TITLE
Isolate tests with ROS_DOMAIN_ID

### DIFF
--- a/apex_launchtest/apex_launchtest/apex_launchtest_main.py
+++ b/apex_launchtest/apex_launchtest/apex_launchtest_main.py
@@ -19,6 +19,7 @@ import os
 import sys
 
 from .apex_runner import ApexRunner
+from .domain_coordinator import get_coordinated_domain_id
 from .junitxml import unittestResultsToXml
 from .print_arguments import print_arguments_of_launch_description
 
@@ -52,6 +53,11 @@ def apex_launchtest_main():
                         default=False,
                         help='Show arguments that may be given to the test file.')
 
+    parser.add_argument('--disable-ros-isolation',
+                        action="store_true",
+                        default=False,
+                        help="Do not set a ROS_DOMAIN_ID.  Useful for debugging ROS tests")
+
     parser.add_argument(
         'launch_arguments',
         nargs='*',
@@ -71,6 +77,11 @@ def apex_launchtest_main():
     if args.verbose:
         _logger_.setLevel(logging.DEBUG)
         _logger_.debug("Running with verbose output")
+
+    if not args.disable_ros_isolation:
+        domain_id = get_coordinated_domain_id()  # Must copy this to a local to keep it alive
+        _logger_.debug("Running with ROS_DOMAIN_ID {}".format(domain_id))
+        os.environ["ROS_DOMAIN_ID"] = str(domain_id)
 
     # Load the test file as a module and make sure it has the required
     # components to run it as an apex integration test

--- a/apex_launchtest/apex_launchtest/domain_coordinator.py
+++ b/apex_launchtest/apex_launchtest/domain_coordinator.py
@@ -1,0 +1,69 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import socket
+
+# To coordinate ROS_DOMAIN_IDs between multiple instances of apex_launchtest, we
+# open a high numbered port "PORT_BASE + ROS_DOMAIN_ID"  If apex_launchtest manages to
+# open the port, it can use that ROS_DOMAIN_ID for the duration of the test run
+_PORT_BASE = 22119  # I picked this randomly as a high port that probably won't be in use
+
+
+class _sockwrapper():
+    """Wraps sockets to keep them open, but appear like a number from 1 to 100."""
+
+    def __init__(self, socket):
+        self.__socket = socket
+
+    def __str__(self):
+        return str(self.__socket.getsockname()[1] - _PORT_BASE)
+
+
+class _default_selector:
+    # By default, when we try to get a unique domain ID we'll start with a random
+    # value, then increment from there until we find one that isn't taken
+
+    def __init__(self):
+        self._value = random.randint(1, 100)
+
+    def __call__(self):
+        retval = ((self._value - 1) % 100) + 1
+        self._value += 1
+        return retval
+
+
+def get_coordinated_domain_id(*, selector=None):
+    """
+    Get a ROS_DOMAIN_ID from 1 to 100 that will not conflict with other ROS_DOMAIN_IDs.
+
+    Other instances of apex_launchtest will use this same function to generate ROS_DOMAIN_IDs
+    so that no two runs of apex_launchtest on the same system should conflict with one-another
+    by default.  This is similar to the ROS1 rostest behavior of putting the ROS master
+    on a unique port
+    """
+    if selector is None:
+        selector = _default_selector()
+
+    # Try 100 times to get a unique ROS domain ID
+    for attempt in range(100):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s.bind(("", _PORT_BASE + selector()))
+        except OSError:
+            continue
+        else:
+            return _sockwrapper(s)
+    else:
+        raise Exception("Failed to get a unique domain ID")

--- a/apex_launchtest/test/test_domain_coordinator.py
+++ b/apex_launchtest/test/test_domain_coordinator.py
@@ -1,0 +1,103 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import apex_launchtest.domain_coordinator
+
+
+class TestUniqueness(unittest.TestCase):
+
+    def test_quickly(self):
+        # Quick and simple test to see that we generate unique domains.  Will not necessarily
+        # find problems because domains are selected randomly.  We're only asking for 10
+        # domains out of 100 so most of the time we'll probably get lucky
+        domains = []
+
+        for _ in range(10):
+            domains.append(apex_launchtest.domain_coordinator.get_coordinated_domain_id())
+
+        domain_ids = list(map(lambda x: str(x), domains))
+
+        self.assertEqual(
+            sorted(domain_ids),
+            sorted(set(domain_ids))  # 'set' will remove duplicates
+        )
+
+    def test_with_forced_collision(self):
+
+        domain = apex_launchtest.domain_coordinator.get_coordinated_domain_id(
+            selector=lambda: 42  # Force it to select '42' as the domain every time it tries
+        )
+        self.assertEquals("42", str(domain))
+
+        # Now that we've already got domain 42 reserved, this call should fail:
+        with self.assertRaises(Exception) as cm:
+            apex_launchtest.domain_coordinator.get_coordinated_domain_id(
+                selector=lambda: 42
+            )
+
+        self.assertIn("Failed to get a unique domain ID", str(cm.exception))
+
+    def test_known_order(self):
+
+        class sequence_gen:
+
+            def __init__(self):
+                self._sequence = 1
+
+            def __call__(self):
+                try:
+                    return self._sequence
+                finally:
+                    self._sequence += 1
+
+        domains = []
+
+        for _ in range(10):
+            domains.append(
+                apex_launchtest.domain_coordinator.get_coordinated_domain_id(
+                    selector=sequence_gen()
+                )
+            )
+
+        self.assertEqual(
+            ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+            list(map(lambda x: str(x), domains))
+        )
+
+
+class TestSelector(unittest.TestCase):
+
+    def test_selector_values_between_1_and_100(self):
+        selector = apex_launchtest.domain_coordinator._default_selector()
+
+        for n in range(200):
+            val = selector()
+            self.assertGreaterEqual(val, 1)
+            self.assertLessEqual(val, 100)
+
+    def test_selector_values_are_unique(self):
+        selector = apex_launchtest.domain_coordinator._default_selector()
+
+        seen_values = []
+
+        # The default sequencer should produce 100 unique values before it starts to repeat.
+        for n in range(100):
+            seen_values.append(selector())
+
+        self.assertEqual(
+            sorted(seen_values),
+            list([n + 1 for n in range(100)])
+        )

--- a/apex_launchtest/test/test_domain_coordinator.py
+++ b/apex_launchtest/test/test_domain_coordinator.py
@@ -15,20 +15,22 @@
 import unittest
 
 import apex_launchtest.domain_coordinator
+from apex_launchtest.domain_coordinator import get_coordinated_domain_id
 
 
 class TestUniqueness(unittest.TestCase):
 
     def test_quickly(self):
-        # Quick and simple test to see that we generate unique domains.  Will not necessarily
-        # find problems because domains are selected randomly.  We're only asking for 10
-        # domains out of 100 so most of the time we'll probably get lucky
-        domains = []
+        """
+        Quick test with false negatives, but simple and easy to understand.
 
-        for _ in range(10):
-            domains.append(apex_launchtest.domain_coordinator.get_coordinated_domain_id())
+        See that we generate unique domains.  Will not necessarily find problems because domains
+        are selected randomly.  We're only asking for 10 domains out of 100 so most of the time
+        we'll probably get lucky.
+        """
+        domains = [get_coordinated_domain_id() for _ in range(10)]
 
-        domain_ids = list(map(lambda x: str(x), domains))
+        domain_ids = [str(domain) for domain in domains]
 
         self.assertEqual(
             sorted(domain_ids),
@@ -40,7 +42,7 @@ class TestUniqueness(unittest.TestCase):
         domain = apex_launchtest.domain_coordinator.get_coordinated_domain_id(
             selector=lambda: 42  # Force it to select '42' as the domain every time it tries
         )
-        self.assertEquals("42", str(domain))
+        self.assertEqual("42", str(domain))
 
         # Now that we've already got domain 42 reserved, this call should fail:
         with self.assertRaises(Exception) as cm:
@@ -63,18 +65,11 @@ class TestUniqueness(unittest.TestCase):
                 finally:
                     self._sequence += 1
 
-        domains = []
-
-        for _ in range(10):
-            domains.append(
-                apex_launchtest.domain_coordinator.get_coordinated_domain_id(
-                    selector=sequence_gen()
-                )
-            )
+        domains = [get_coordinated_domain_id(selector=sequence_gen()) for _ in range(10)]
 
         self.assertEqual(
             ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
-            list(map(lambda x: str(x), domains))
+            [str(domain) for domain in domains]
         )
 
 
@@ -91,13 +86,10 @@ class TestSelector(unittest.TestCase):
     def test_selector_values_are_unique(self):
         selector = apex_launchtest.domain_coordinator._default_selector()
 
-        seen_values = []
-
         # The default sequencer should produce 100 unique values before it starts to repeat.
-        for n in range(100):
-            seen_values.append(selector())
+        seen_values = [selector() for _ in range(100)]
 
         self.assertEqual(
             sorted(seen_values),
-            list([n + 1 for n in range(100)])
+            [n + 1 for n in range(100)]
         )


### PR DESCRIPTION
It turns out I didn't have to plumb anything into launch to get this working.  If I jam the ROS_DOMAIN_ID into os.environ for the apex_launchtest process, it will propagate down to the launched processes

I tested this on PR https://github.com/ApexAI/apex_rostest/pull/29.  If I run with --disable-ros-isolation, I can `ros2 topic echo /chatter` and see the data from the running test.  If I run without --disable-ros-isolation, I don't see anything from the echo, but the test continues to pass

@wjwwood or @hidmic  Can you review/approve this?  We prevent ROS_DOMAIN_ID collisions by opening a port between 22120 and 22219.  I picked the range randomly - it's possible there's a better range to use.  The new tests added are primarily about making sure the collision avoidance stuff works.