### PR TITLE
Give more info when output is not in expected sequence

### DIFF
--- a/apex_launchtest/apex_launchtest/asserts/assert_sequential_output.py
+++ b/apex_launchtest/apex_launchtest/asserts/assert_sequential_output.py
@@ -50,7 +50,10 @@ class SequentialTextChecker:
             array_index += 1
             substring_index = 0
 
-        assert False, "'{}' not found in output. Output near the last matched line:\n{}".format(
+        assert False, (
+            "'{}' not found in sequence after previous match.  "
+            "The output near the last matched line:\n{}"
+        ).format(
             msg,
             self.get_nearby_lines()
         )
@@ -64,11 +67,11 @@ class SequentialTextChecker:
         start_idx = max(0, self._array_index - 2)
         end_idx = self._array_index + 4
 
-        full_text = "\n".join(self._output[start_idx:end_idx]) + '\n'
+        full_text = "".join(self._output[start_idx:end_idx])
 
         current_absolute_position = self._substring_index
         for txt in self._output[start_idx:self._array_index]:
-            current_absolute_position += len(txt) + 1
+            current_absolute_position += len(txt)
 
         start_abs_position = current_absolute_position
         for _ in range(3):

--- a/apex_launchtest/apex_launchtest/asserts/assert_sequential_output.py
+++ b/apex_launchtest/apex_launchtest/asserts/assert_sequential_output.py
@@ -50,7 +50,40 @@ class SequentialTextChecker:
             array_index += 1
             substring_index = 0
 
-        assert False, "{} not found in output".format(msg)
+        assert False, "'{}' not found in output. Output near the last matched line:\n{}".format(
+            msg,
+            self.get_nearby_lines()
+        )
+
+    def get_nearby_lines(self):
+
+        # This works by concatinating a few of the process_io outputs that we received, then
+        # searching forward and backward for two return-lines in each direction, then returning
+        # just that portion to give context about where a failure happened
+
+        start_idx = max(0, self._array_index - 2)
+        end_idx = self._array_index + 4
+
+        full_text = "\n".join(self._output[start_idx:end_idx]) + '\n'
+
+        current_absolute_position = self._substring_index
+        for txt in self._output[start_idx:self._array_index]:
+            current_absolute_position += len(txt) + 1
+
+        start_abs_position = current_absolute_position
+        for _ in range(3):
+            start_abs_position = max(full_text.rfind('\n', 0, start_abs_position), 0)
+
+        if start_abs_position != 0:
+            # Complicated, but if the start_abs_position is not zero, it's pointed to a \n
+            # we need to increment by 1 so the leading \n is not in the resulting text
+            start_abs_position += 1
+
+        end_abs_position = current_absolute_position
+        for _ in range(3):
+            end_abs_position = max(full_text.find('\n', end_abs_position + 1), end_abs_position)
+
+        return full_text[start_abs_position:end_abs_position]
 
 
 @contextmanager

--- a/apex_launchtest/examples/good_proc.test.py
+++ b/apex_launchtest/examples/good_proc.test.py
@@ -81,7 +81,7 @@ class TestProcessOutput(unittest.TestCase):
 
     def test_out_of_order(self):
         # This demonstrates that we notice out-of-order IO
-        with self.assertRaisesRegexp(AssertionError, "Loop 2 not found"):
+        with self.assertRaisesRegexp(AssertionError, "'Loop 2' not found"):
 
             with assertSequentialStdout(self.proc_output, dut_process) as cm:
                 cm.assertInStdout("Loop 1")

--- a/apex_launchtest/test/test_sequential_output_checker.py
+++ b/apex_launchtest/test/test_sequential_output_checker.py
@@ -93,3 +93,151 @@ class TestAssertSequentialStdout(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             self.dut.assertInStdout("yyyyy")
+
+    # We want the error message to display the line we last matched, plus two lines before and
+    # two lines after
+    # The test cases below check that the error message contains useful information for the
+    # following test cases:
+    # 1. No matching has ocurred yet
+    # 2. We just matched the first line of output so there are no lines before to print
+    # 3. We just matched the last line of output so there are no lines after to print
+    # 4. We just matched the second line of output so there is only one line before to print
+    # 5. We just matched the second to last line of output so there's only one line after to print
+    # 6. We match a line in the middle, so there are two lines before and after to print
+
+    def test_checker_error_message_1(self):
+        with self.assertRaises(AssertionError) as cm:
+            self.dut.assertInStdout("I am the very model of a modern major general")
+
+        print(cm.exception)
+
+        expected = "output 10\noutput 15\noutput 20"
+        self.assertIn(
+            expected,
+            str(cm.exception)
+        )
+        self.assertEqual(
+            expected,
+            self.dut.get_nearby_lines()
+        )
+
+    def test_checker_error_message_2(self):
+        # In this test, our current line is still the 0th line.
+        with self.assertRaises(AssertionError) as cm:
+            self.dut.assertInStdout("output")
+            self.dut.assertInStdout("I am the very model of a modern major general")
+
+        print(cm.exception)
+
+        expected = "output 10\noutput 15\noutput 20"
+
+        self.assertIn(
+            expected,
+            str(cm.exception)
+        )
+
+        self.assertEqual(
+            expected,
+            self.dut.get_nearby_lines()
+        )
+
+    def test_checker_error_message_3(self):
+        with self.assertRaises(AssertionError) as cm:
+            self.dut.assertInStdout("!@#")
+            self.dut.assertInStdout("I am the very model of a modern major general")
+
+        print(cm.exception)
+
+        expected = "zzzzz\noutput 20\n!@#$%^&*()"
+
+        self.assertIn(
+            expected,
+            str(cm.exception)
+        )
+
+        self.assertEqual(
+            expected,
+            self.dut.get_nearby_lines()
+        )
+
+    def test_checker_error_message_4(self):
+        # Because we asserted on the whole first line.  Our current line is
+        # now the 1st line, so we expect to see 0th, 1 (current), 2, and 3 (current + 2) in the
+        # error message output
+        with self.assertRaises(AssertionError) as cm:
+            self.dut.assertInStdout("output 10")
+            self.dut.assertInStdout("I am the very model of a modern major general")
+
+        print(cm.exception)
+
+        expected = "output 10\noutput 15\noutput 20\nmulti-line 1"
+
+        self.assertIn(
+            expected,
+            str(cm.exception)
+        )
+
+        self.assertEqual(
+            expected,
+            self.dut.get_nearby_lines()
+        )
+
+    def test_checker_error_message_4_1(self):
+        # Match the middle of the 2nd line - should behave the same as test message_4 above
+        with self.assertRaises(AssertionError) as cm:
+            self.dut.assertInStdout("output")
+            self.dut.assertInStdout("output")
+            self.dut.assertInStdout("I am the very model of a modern major general")
+
+        print(cm.exception)
+
+        expected = "output 10\noutput 15\noutput 20\nmulti-line 1"
+
+        self.assertIn(
+            expected,
+            str(cm.exception)
+        )
+
+        self.assertEqual(
+            expected,
+            self.dut.get_nearby_lines()
+        )
+
+    def test_checker_error_message_5(self):
+        with self.assertRaises(AssertionError) as cm:
+            self.dut.assertInStdout("output 20")
+            self.dut.assertInStdout("output 2")
+            self.dut.assertInStdout("I am the very model of a modern major general")
+
+        print(cm.exception)
+
+        expected = "some dummy text\nzzzzz\noutput 20\n!@#$%^&*()"
+
+        self.assertIn(
+            expected,
+            str(cm.exception)
+        )
+
+        self.assertEqual(
+            expected,
+            self.dut.get_nearby_lines()
+        )
+
+    def test_checker_error_message_6(self):
+        with self.assertRaises(AssertionError) as cm:
+            self.dut.assertInStdout("multi")
+            self.dut.assertInStdout("I am the very model of a modern major general")
+
+        print(cm.exception)
+
+        expected = "output 15\noutput 20\nmulti-line 1\nmulti-line 2\nmulti-line 3"
+
+        self.assertIn(
+            expected,
+            str(cm.exception)
+        )
+
+        self.assertEqual(
+            expected,
+            self.dut.get_nearby_lines()
+        )

--- a/apex_launchtest/test/test_sequential_output_checker.py
+++ b/apex_launchtest/test/test_sequential_output_checker.py
@@ -21,14 +21,14 @@ class TestAssertSequentialStdout(unittest.TestCase):
 
     def setUp(self):
         self.to_check = [
-            "output 10",
-            "output 15",
-            "output 20",
-            "multi-line 1\nmulti-line 2\nmulti-line 3",
-            "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj",  # long line
-            "xxxxx yyyyy\nsome dummy text\nzzzzz",  # mix of long line and multi-line
-            "output 20",
-            "!@#$%^&*()",  # Help find off by one errors in the substring logic
+            "output 10\n",
+            "output 15\n",
+            "output 20\n",
+            "multi-line 1\nmulti-line 2\nmulti-line 3\n",
+            "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj\n",  # long line
+            "xxxxx yyyyy\nsome dummy text\nzzzzz\n",  # mix of long line and multi-line
+            "output 20\n",
+            "!@#$%^&*()\n",  # Help find off by one errors in the substring logic
         ]
 
         self.dut = SequentialTextChecker(self.to_check)


### PR DESCRIPTION
We had a problem with one of our tests where it failed because some of the output was a little out of order occasionally.  The test output itself wasn't very helpful to diagnose the problem.

This PR improves the error message you get when you assert that output is sequential.  It will print the last line that you matched on, and up to two previous lines and up to two following lines.

### Note to Reviewer
The get_nearby_lines method (like the reset of the SequentialTextChecker) is a bit of a mess, but it's well covered with tests.  I'm open to better ways to do this, but the way the data is stored behind the scenes isn't super natural for searching backwards and forwards.

You can test this by editing good_proc.test.py.  Remove [this line](https://github.com/ApexAI/apex_rostest/blob/f8457a4ac7a11a5cc772da3d196940fd81238270/apex_launchtest/examples/good_proc.test.py#L84) and fix up the indentation, then run
>apex_launchtest examples/good_proc.test.py
and you'll see the new exception output.  Right now it looks like this:

```bash
======================================================================
FAIL: test_out_of_order (python_launch_file.TestProcessOutput)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pete.baughman/apex_rostest/apex_launchtest/examples/good_proc.test.py", line 89, in test_out_of_order
    cm.assertInStdout("Loop 2")  # This should raise
  File "/home/pete.baughman/apex_rostest/install/lib/python3.5/site-packages/apex_launchtest/asserts/assert_sequential_output.py", line 58, in assertInStdout
    self.get_nearby_lines()
AssertionError: 'Loop 2' not found in sequence after previous match.  The output near the last matched line:
Loop 1
Loop 2
Loop 3
Loop 4
Shutting Down

```

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>