### PR TITLE
Fix exception with process name resolution, add test

### DIFF
--- a/apex_launchtest/apex_launchtest/util/proc_lookup.py
+++ b/apex_launchtest/apex_launchtest/util/proc_lookup.py
@@ -21,12 +21,40 @@ class NoMatchingProcessException(Exception):
     pass
 
 
+class _FakeContextException(Exception):
+    pass
+
+
+class _fake_context:
+
+    def __getattr__(self, attr):
+        # If anything actually tries to use our fake context, we will raise an exception
+        # that we can recognize.
+        raise _FakeContextException()
+
+
 def _proc_to_name_and_args(proc):
     # proc is a launch.actions.ExecuteProcess
-    return "{} {}".format(
-        proc.process_details['name'],
-        " ".join(proc.process_details['cmd'][1:])
-    )
+
+    if proc.process_details:
+        # process_details are added by the launch system when the process is started.
+        # Before the process starts, this will be None
+        return "{} {}".format(
+            proc.process_details['name'],
+            " ".join(proc.process_details['cmd'][1:])
+        )
+    else:
+        # Process has not been launched yet, so we don't yet know the process name.
+        # In the special case where the process's name is all TextSubstitutions, we
+        # can resolve the name.  If there are any other substitutions, we can't give
+        # additional info until after the process is launched
+        def perform_subs(subs):
+            return ''.join([sub.perform(_fake_context()) for sub in subs])
+        try:
+            cmd = [perform_subs(sub) for sub in proc.cmd]
+            return " ".join(cmd)
+        except _FakeContextException:
+            return "Unknown - Process not launched yet"
 
 
 def _str_name_to_process(info_obj, proc_name, cmd_args):

--- a/apex_launchtest/test/test_resolve_process.py
+++ b/apex_launchtest/test/test_resolve_process.py
@@ -1,0 +1,69 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import launch.actions
+import launch.substitutions
+
+import apex_launchtest
+import apex_launchtest.util
+
+
+class TestResolveProcess(unittest.TestCase):
+
+    def test_unlaunched_process_lookup(self):
+        # Regression test for https://github.com/ApexAI/apex_rostest/issues/35
+
+        info_obj = apex_launchtest.ProcInfoHandler()
+
+        lookup_obj = launch.actions.ExecuteProcess(
+            cmd=[
+                'python',
+                '-c',
+                '',
+            ]
+        )
+
+        with self.assertRaises(apex_launchtest.util.NoMatchingProcessException) as cm:
+            apex_launchtest.util.resolveProcesses(
+                info_obj,
+                process=lookup_obj
+            )
+
+        # We'll get a good error mesasge here because there were no substitutions in
+        # the execute process cmd - it's all text
+        self.assertIn("python -c", str(cm.exception))
+
+    def test_unlaunched_process_lookup_with_substitutions(self):
+        info_obj = apex_launchtest.ProcInfoHandler()
+
+        lookup_obj = launch.actions.ExecuteProcess(
+            cmd=[
+                launch.substitutions.LocalSubstitution("foo"),
+                'python',
+                '-c',
+                '',
+            ]
+        )
+
+        with self.assertRaises(apex_launchtest.util.NoMatchingProcessException) as cm:
+            apex_launchtest.util.resolveProcesses(
+                info_obj,
+                process=lookup_obj
+            )
+
+        # Since the process wasn't launched yet, and it has substitutions that need to be
+        # resolved by the launch system, we won't be able to take a guess at the command
+        self.assertIn("Unknown", str(cm.exception))


### PR DESCRIPTION
Fixes #35 

Before this fix, if you tried to assert that a process exited before it had been launched, the assert would blow up.  `assertWaitForShutdown` is designed to catch a NoMatchingProcessException and retry, but part of making a NoMatchingProcessException is formatting the error message which would fail if you tried to do it before the process launched

This fix improves _proc_to_name_and_args to handle the case where the process has not launched yet.  Two regression tests were added as well.