### PR TITLE
Improve handling of skipped tests

### DIFF
--- a/apex_launchtest/apex_launchtest/apex_runner.py
+++ b/apex_launchtest/apex_launchtest/apex_runner.py
@@ -231,6 +231,7 @@ class ApexRunner(object):
             except unittest.case.SkipTest as skip_exception:
                 # If a 'skip' decorator was placed on the generate_launch_description function,
                 # we skip all the tests for that run
+                print('{} is skipped: {}'.format(run, skip_exception))
                 results[run] = SkipResult(msg=str(skip_exception))
                 continue
             except _LaunchDiedException:

--- a/apex_launchtest/apex_launchtest/apex_runner.py
+++ b/apex_launchtest/apex_launchtest/apex_runner.py
@@ -26,7 +26,7 @@ from launch.event_handlers import OnProcessIO
 from .io_handler import ActiveIoHandler
 from .parse_arguments import parse_launch_arguments
 from .proc_info_handler import ActiveProcInfoHandler
-from .test_result import FailResult, TestResult
+from .test_result import FailResult, SkipResult, TestResult
 
 
 class _LaunchDiedException(Exception):
@@ -228,6 +228,11 @@ class ApexRunner(object):
             try:
                 worker = _RunnerWorker(run, self._launch_file_arguments, self._debug)
                 results[run] = worker.run()
+            except unittest.case.SkipTest as skip_exception:
+                # If a 'skip' decorator was placed on the generate_launch_description function,
+                # we skip all the tests for that run
+                results[run] = SkipResult(msg=str(skip_exception))
+                continue
             except _LaunchDiedException:
                 # The most likely cause was ctrl+c, so we'll abort the test run
                 results[run] = FailResult()

--- a/apex_launchtest/apex_launchtest/junitxml.py
+++ b/apex_launchtest/apex_launchtest/junitxml.py
@@ -81,7 +81,8 @@ def unittestCaseToXml(test_result, test_case):
     class needs to be an apex_launchtest TestResult class
     """
     case_xml = ET.Element('testcase')
-    case_xml.set('name', type(test_case).__name__ + '.' + test_case._testMethodName)
+    case_xml.set('classname', type(test_case).__name__)
+    case_xml.set('name', test_case._testMethodName)
     case_xml.set('time', str(round(test_result.testTimes[test_case], 3)))
 
     for failure in test_result.failures:
@@ -101,7 +102,7 @@ def unittestCaseToXml(test_result, test_case):
     for skip in test_result.skipped:
         if skip[0] == test_case:
             skip_xml = ET.Element('skipped')
-            skip_xml.text = skip[1]
+            skip_xml.set('message', skip[1])
             case_xml.append(skip_xml)
 
     return case_xml

--- a/apex_launchtest/apex_launchtest/test_result.py
+++ b/apex_launchtest/apex_launchtest/test_result.py
@@ -33,6 +33,32 @@ class FailResult(unittest.TestResult):
         return False
 
 
+class SkipResult(unittest.TestResult):
+    """For test runs with a skip decorator on the generate_test_description function."""
+
+    class __skipped_test_case:
+
+        def __init__(self):
+            self._testMethodName = 'skipped_launch'
+
+    def __init__(self, stream=None, descriptions=None, verbosity=None, msg=''):
+        super().__init__(stream, descriptions, verbosity)
+        self.__tc = SkipResult.__skipped_test_case()
+        self.skipped.append((self.__tc, msg))
+
+    @property
+    def testCases(self):
+        return [self.__tc]
+
+    @property
+    def testTimes(self):
+        """Get a dict of {test_case: elapsed_time}."""
+        return {self.__tc: 0}
+
+    def wasSuccessful(self):
+        return True
+
+
 class TestResult(unittest.TextTestResult):
     """
     Subclass of unittest.TestResult that collects more information about the tests that ran.

--- a/apex_launchtest/test/test_runner_results.py
+++ b/apex_launchtest/test/test_runner_results.py
@@ -214,3 +214,35 @@ def test_parametrized_run_with_one_failure():
 
     assert len(passes) == 3  # 1, 4, and 5 should pass
     assert len(fails) == 2  # 2 fails in an active test, 3 fails in a post-shutdown test
+
+
+def test_skipped_launch_description():
+
+    @unittest.skip('skip reason string')
+    def generate_test_description(ready_fn):
+        raise Exception('This should never be invoked')  # pragma: no cover
+
+    class FakePreShutdownTests(unittest.TestCase):
+
+        def test_fail_always(self):
+            assert False  # pragma: no cover
+
+    @apex_launchtest.post_shutdown_test()
+    class FakePostShutdownTests(unittest.TestCase):
+
+        def test_fail_always(self):
+            assert False  # pragma: no cover
+
+    test_module = types.ModuleType('test_module')
+    test_module.generate_test_description = generate_test_description
+    test_module.FakePreShutdownTests = FakePreShutdownTests
+    test_module.FakePostShutdownTests = FakePostShutdownTests
+
+    # Run the test:
+    runner = ApexRunner(
+        LoadTestsFromPythonModule(test_module)
+    )
+
+    results = runner.run()
+    # Should just get one result, even though there were multiple tests
+    assert len(results.values()) == 1

--- a/apex_launchtest/test/test_xml_output.py
+++ b/apex_launchtest/test/test_xml_output.py
@@ -65,12 +65,30 @@ class TestGoodXmlOutput(unittest.TestCase):
         # Drilling down a little further, we expect the class names to show up in the testcase
         # names
         case_names = [case.attrib['name'] for case in test_suite.getchildren()]
-        self.assertIn('TestGoodProcess.test_count_to_four', case_names)
-        self.assertIn('TestProcessOutput.test_full_output', case_names)
+        self.assertIn('test_count_to_four', case_names)
+        self.assertIn('test_full_output', case_names)
 
 
 class TestXmlFunctions(unittest.TestCase):
     # This are closer to unit tests - just call the functions that generate XML
+
+    def unit_test_result_factory(self, test_case_list):
+        # Use the unittest library to run some fake test functions and generate a real TestResult
+        # that we can serialize to XML
+
+        class TestHost(unittest.TestCase):
+            pass
+
+        for n, test_case in enumerate(test_case_list):
+            setattr(TestHost, 'test_{}'.format(n), test_case)
+
+        cases = unittest.TestLoader().loadTestsFromTestCase(TestHost)
+        with open(os.devnull, 'w') as nullstream:
+            runner = unittest.TextTestRunner(
+                stream=nullstream,
+                resultclass=TR
+            )
+            return runner.run(cases)
 
     def test_fail_results_serialize(self):
         xml_tree = unittestResultsToXml(
@@ -96,3 +114,152 @@ class TestXmlFunctions(unittest.TestCase):
 
         child_names = [chld.attrib['name'] for chld in xml_tree.getroot().getchildren()]
         self.assertEqual(set(child_names), {'launch_1', 'launch_2', 'launch_3'})
+
+    def test_result_that_ran(self):
+        # This mostly validates the test setup
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    lambda self: None
+                ])
+            }
+        )
+
+        # The expected structure for this test is:
+        # <testsuites>
+        #   <testsuite name="run1" . . . >
+        #     <testcase classname="TestHost" name="test_0" . . . />
+        #   </testsuite>
+        # <testsuites>
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+
+        # The bare minimum XML we require:
+        self.assertEqual('0', testsuite_element.attrib['failures'])
+        self.assertEqual('0', testsuite_element.attrib['errors'])
+        self.assertEqual('1', testsuite_element.attrib['tests'])
+        self.assertEqual('test_0', testcase_element.attrib['name'])
+        self.assertEqual('TestHost', testcase_element.attrib['classname'])
+
+    def test_result_with_skipped_test(self):
+
+        @unittest.skip('My reason is foo')
+        def test_that_is_skipped(self):
+            pass  # pragma: no cover
+
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    test_that_is_skipped
+                ])
+            }
+        )
+
+        # The expected structure for this test is:
+        # <testsuites>
+        #   <testsuite name="run1" . . . >
+        #     <testcase classname="TestHost" name="test_0" . . . >
+        #       <skipped message="My reason is foo" . . . />
+        #     </testcase>
+        #   </testsuite>
+        # <testsuites>
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+        skip_element = testcase_element.find('skipped')
+
+        self.assertEqual('1', testsuite_element.attrib['skipped'])
+        self.assertEqual('My reason is foo', skip_element.attrib['message'])
+
+    def test_result_with_failure(self):
+
+        def test_that_fails(self):
+            assert 1 == 2
+
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    test_that_fails
+                ])
+            }
+        )
+
+        # The expected structure for this test is:
+        # <testsuites>
+        #   <testsuite name="run1" . . . >
+        #     <testcase classname="TestHost" name="test_0" . . . >
+        #       <failure message="assert 1 == 2" . . .>
+        #       </failure>
+        #     </testcase>
+        #   </testsuite>
+        # <testsuites>
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+        failure_element = testcase_element.find('failure')
+
+        self.assertEqual('1', testsuite_element.attrib['failures'])
+        self.assertIn('1 == 2', failure_element.attrib['message'])
+
+    def test_result_with_error(self):
+
+        def test_that_errors(self):
+            raise Exception('This is an error')
+
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    test_that_errors
+                ])
+            }
+        )
+
+        # The expected structure for this test is:
+        # <testsuites>
+        #   <testsuite name="run1" . . . >
+        #     <testcase classname="TestHost" name="test_0" . . . >
+        #       <error message="This is an error" . . .>
+        #       </failure>
+        #     </testcase>
+        #   </testsuite>
+        # <testsuites>
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+        error_element = testcase_element.find('error')
+
+        self.assertEqual('1', testsuite_element.attrib['errors'])
+        self.assertIn('This is an error', error_element.attrib['message'])
+
+    def test_with_multiple_results(self):
+
+        def good_test(self):
+            pass
+
+        def error_test(self):
+            raise Exception('I am an error')
+
+        def fail_test(self):
+            assert 1 == 2
+
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    good_test,
+                    error_test,
+                    fail_test,
+                ])
+            }
+        )
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+
+        self.assertEqual('1', testsuite_element.attrib['failures'])
+        self.assertEqual('1', testsuite_element.attrib['errors'])
+        self.assertEqual('3', testsuite_element.attrib['tests'])

--- a/apex_launchtest/test/test_xml_output.py
+++ b/apex_launchtest/test/test_xml_output.py
@@ -21,6 +21,7 @@ import xml.etree.ElementTree as ET
 import ament_index_python
 from apex_launchtest.junitxml import unittestResultsToXml
 from apex_launchtest.test_result import FailResult
+from apex_launchtest.test_result import SkipResult
 from apex_launchtest.test_result import TestResult as TR
 
 
@@ -101,6 +102,23 @@ class TestXmlFunctions(unittest.TestCase):
         # Simple sanity check - see that there's a child element called active_tests
         child_names = [chld.attrib['name'] for chld in xml_tree.getroot().getchildren()]
         self.assertEqual(set(child_names), {'active_tests'})
+
+    def test_skip_results_serialize(self):
+        xml_tree = unittestResultsToXml(
+            name='skip_xml',
+            test_results={
+                'active_tests': SkipResult(msg='skip message')
+            }
+        )
+
+        # Make sure the message got into the 'skip' element
+        testsuites_element = xml_tree.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+        skip_element = testcase_element.find('skipped')
+
+        self.assertEqual('1', testsuite_element.attrib['skipped'])
+        self.assertEqual('skip message', skip_element.attrib['message'])
 
     def test_multiple_test_results(self):
         xml_tree = unittestResultsToXml(


### PR DESCRIPTION
Resolves issue https://github.com/ApexAI/apex_rostest/issues/40

### Merge Order
  - https://github.com/ApexAI/apex_rostest/pull/39
  - This PR

Fixes the junit XML to match the XML generated by pytest more closely.  Specifically, using 'classname' and 'name' attributes in TestCase and setting the 'message' attribute in the skip element for skipped tests.

This PR also introduces a feature allowing the `@unittest.skip()` decorator to be put on a generate_launch_description function to skip the whole launch.